### PR TITLE
chore: finalize v0.1.0 release documentation

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -20,7 +20,7 @@ main (always deployable)
 
 - `main` is always deployable
 - All work on feature branches
-- Merge via PR (or direct for tiny changes)
+- **ALL changes merge via PR** (never push directly to main)
 - Delete branches after merge
 - Tag releases directly on main
 - No `develop` or `release/` branches
@@ -204,12 +204,14 @@ git branch --merged main | grep -v "main" | xargs git branch -d
 
 ### NEVER Do Without Explicit Approval
 
+- `git push origin main` (direct push to main)
 - `git push --force` or `git push -f`
 - `git reset --hard`
 - `git checkout .` or `git restore .`
 - `git clean -f`
 - `git branch -D`
 - Force push to main/master
+- `gh pr merge` without PR review
 
 ### Always Get Approval For
 

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -2,6 +2,29 @@
 
 Standards for version control, branching, commits, and releases.
 
+## Workflow: GitHub Flow
+
+This project uses **GitHub Flow** (simple, not Git Flow):
+
+```text
+main (always deployable)
+  │
+  ├── feat/add-model ──→ PR ──→ merge ──→ delete branch
+  ├── fix/broken-test ──→ PR ──→ merge ──→ delete branch
+  ├── docs/update-readme ──→ PR ──→ merge ──→ delete branch
+  │
+  └── tag v0.2.0 (when milestone reached)
+```
+
+**Key principles:**
+
+- `main` is always deployable
+- All work on feature branches
+- Merge via PR (or direct for tiny changes)
+- Delete branches after merge
+- Tag releases directly on main
+- No `develop` or `release/` branches
+
 ## Branch Naming
 
 ### Format
@@ -12,11 +35,11 @@ Standards for version control, branching, commits, and releases.
 
 | Prefix | Purpose | Example |
 |--------|---------|---------|
-| `feat/` | New features or content | `feat/shopping-dialogue-page` |
-| `fix/` | Bug fixes | `fix/navigation-link-broken` |
+| `feat/` | New features or content | `feat/add-patients-model` |
+| `fix/` | Bug fixes | `fix/broken-test` |
 | `docs/` | Documentation changes | `docs/update-architecture` |
-| `refactor/` | Code restructuring | `refactor/shared-js-cleanup` |
-| `style/` | CSS/styling changes | `style/flashcard-hover-effects` |
+| `refactor/` | Code restructuring | `refactor/cleanup-staging` |
+| `style/` | CSS/styling changes | `style/format-sql` |
 | `chore/` | Maintenance tasks | `chore/update-dependencies` |
 
 ### Guidelines
@@ -130,6 +153,52 @@ git show v0.3.0
 - After merging significant PRs
 - At version milestones
 - Before major refactoring (restore point)
+
+### When NOT to Tag
+
+Not every merge requires a version bump. These accumulate in `[Unreleased]`:
+
+| Change Type | Version Bump? | Example |
+|-------------|---------------|---------|
+| New feature | MINOR | Adding staging models |
+| Bug fix | PATCH | Fixing broken test |
+| Docs only | No | Updating README |
+| Chores | No | Dependency updates |
+| Refactors | No (usually) | Code cleanup |
+| Style/format | No | SQL formatting |
+
+**Rule**: Tag when there's meaningful user-facing change or milestone completion.
+
+## Branch Hygiene
+
+### Delete After Merge
+
+Always delete branches after merging to keep the repo tidy:
+
+```bash
+# Delete local branch
+git branch -d feat/my-feature
+
+# Delete remote branch
+git push origin --delete feat/my-feature
+
+# Prune stale remote tracking branches
+git fetch --prune
+```
+
+### GitHub Auto-Delete
+
+Enable "Automatically delete head branches" in repo settings to auto-cleanup after PR merge.
+
+### Periodic Cleanup
+
+```bash
+# List merged branches (safe to delete)
+git branch --merged main
+
+# Delete all merged local branches except main
+git branch --merged main | grep -v "main" | xargs git branch -d
+```
 
 ## Protected Operations
 

--- a/.claude/skills/deployment-workflow.md
+++ b/.claude/skills/deployment-workflow.md
@@ -15,6 +15,16 @@ Invoke when:
 - Ready for release
 - User requests deployment
 
+## Git Workflow: GitHub Flow
+
+This project uses **GitHub Flow** (not Git Flow):
+
+- `main` is always deployable
+- All work done on feature branches (`feat/`, `fix/`, `docs/`, `chore/`)
+- Branches merge to main via PR
+- Tags mark releases directly on main
+- No `develop` or `release/` branches needed
+
 ## Deployment Workflow
 
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,50 +20,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Initial project scaffold forked from agent orchestration template
-- Agent orchestration system with 10 personas:
-  - Product Manager, Architect, Developer, Code Reviewer
-  - Tester, Documenter, Security Reviewer, Design Reviewer
-  - Git-Master, Sage, Changelog Generator
-- Documentation framework:
-  - `docs/guides/` - How-to workflows
-  - `docs/standards/` - Rules and conventions
-  - `docs/reference/` - Technical documentation
-  - `docs/specs/` - PRDs
-  - `docs/tdd/` - Technical design docs
-- Agent configuration in `.claude/`:
-  - 10+ agent persona files
-  - 8 slash commands (/plan, /review, /commit, /branch, /orchestrate, /deploy, /tdd, /repo-research)
-  - 14+ reusable workflow skills
-  - 4 coding rules (coding-style, git-workflow, testing, security)
-  - Pre/post tool hooks
-  - Utility scripts
-- Git governance via git-master agent with enforcement hooks
+- **Agent System**: Complete dbt development agent orchestration with 16 personas
+  - Base agents: Product Manager, Architect, Developer, Code Reviewer, Tester, Documenter, Security Reviewer, Design Reviewer, Git-Master, Sage, Changelog Generator
+  - dbt agents: data-modeler, dbt-developer, dbt-tester, dbt-documenter, semantic-analyst
 
-### Removed
+- **Skills**: 21 workflow skills including 6 dbt-specific
+  - dbt-model-development, dbt-testing, dbt-code-review, dbt-deployment, dbt-source-onboarding, dbt-semantic-layer
 
-- Japanese study site content (previous project)
-- Domain-specific content directories (content/, topics/, kanji/)
-- Japanese-specific agents (sensei)
-- Japanese-specific skills (kanji-content-creation, topic-page-creation)
-- Japanese-specific rules (japanese-content.md)
-- Japanese documentation (CONTENT_STANDARDS.md, ROADMAP.md)
-- Previous version archives (v0.0-v0.2)
-- Japanese PRDs and TDDs
+- **Commands**: 13 slash commands including 5 for dbt
+  - `/dbt-model`, `/dbt-test`, `/dbt-run`, `/dbt-docs`, `/dbt-query`
+
+- **Documentation**: Comprehensive project planning
+  - DBT-PROJECT-INITIALIZATION.md: 8-phase technical plan
+  - ROADMAP.md: 6 epics, 4 milestones (v0.2-v0.5)
+  - GITHUB-ISSUES.md: 41 actionable issues
+  - 4 PRDs, 1 TDD for architecture decisions
+  - Kimball dimensional modeling reference guide
+
+- **Infrastructure**
+  - GitHub project with 40 issues and 4 milestones
+  - markdownlint-cli2 with pre-commit hooks
+  - dbt-mcp server configuration
+  - GitHub Flow workflow documentation
 
 ### Changed
 
 - Rebranded from "japanese-study-site" to "dbt-playground"
-- Updated all documentation for generic data project use
-- Simplified project structure for dbt development
+- Updated workflow to GitHub Flow (no release branches)
+- Added branch hygiene and versioning strategy documentation
+
+### Fixed
+
+- ~400 markdown formatting issues via linting
+
+### Removed
+
+- Japanese study site content and domain-specific agents
+- Previous version archives (now using git tags)
 
 ---
 
 ## Version History
 
-| Version | Date       | Highlights                                |
-| ------- | ---------- | ----------------------------------------- |
-| 0.1.0   | 2026-01-28 | Initial scaffold with agent orchestration |
+| Version | Date       | Highlights                                         |
+| ------- | ---------- | -------------------------------------------------- |
+| 0.1.0   | 2026-01-28 | Agent orchestration + dbt project planning complete |
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,7 @@ Store in `temp/` during active development:
 2. **Skip the planning step** - plan before implementing
 3. **Assume understanding** - ask questions if the pattern isn't clear
 4. **Commit without testing** - verify functionality before finalizing
-5. **Commit directly to main** - always use feature branches and PRs
+5. **Push or merge directly to main** - ALL changes go through feature branches and PRs, no exceptions
 6. **Execute git write operations directly** - all git commit/push/merge/tag must go through git-master
 7. **Bypass git-master enforcement** - the hook blocks direct git writes for safety
 


### PR DESCRIPTION
## Summary

Finalize v0.1.0 release with GitHub Flow workflow documentation and comprehensive changelog.

## Changes

- **git-workflow.md**: Added GitHub Flow section with visual diagram, branch hygiene guidelines, and "when NOT to tag" policy
- **deployment-workflow.md**: Updated to remove release branches, align with GitHub Flow
- **CHANGELOG.md**: Comprehensive v0.1.0 entries documenting all agents, skills, commands, and infrastructure

## Key Decisions

- Use GitHub Flow (simple): main + feature branches only
- Delete branches after merge (auto-delete enabled)
- Only tag for meaningful changes (features, fixes), not docs/chores
- Docs/chores accumulate in `[Unreleased]` until next feature release

## Post-Merge

After merging, create tag on main:
```bash
git tag -a v0.1.0 -m "Initial release: Agent orchestration + dbt project planning"
git push origin v0.1.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)