### PR TITLE
refactor: rename dbt project to healthcare_analytics

### DIFF
--- a/dbt_project/dbt_project.yml
+++ b/dbt_project/dbt_project.yml
@@ -1,8 +1,8 @@
-name: 'dbt_playground'
+name: 'healthcare_analytics'
 version: '0.1.0'
 config-version: 2
 
-profile: 'dbt_playground'
+profile: 'healthcare_analytics'
 
 # File paths
 model-paths: ["models"]
@@ -18,7 +18,7 @@ clean-targets:
 
 # Model configurations by layer
 models:
-  dbt_playground:
+  healthcare_analytics:
     staging:
       +materialized: view
       +schema: staging


### PR DESCRIPTION
## Summary

Rename the dbt project from `dbt_playground` to `healthcare_analytics` for a more descriptive name.

## Changes

- Updated `dbt_project.yml` name and profile references
- Updated `~/.dbt/profiles.yml` profile name (local only)

## Verification

```bash
dbt debug  # All checks passed!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)