### PR TITLE
feat(agents): add healthcare-analyst domain expert persona

### DIFF
--- a/.claude/agents/AGENTS.md
+++ b/.claude/agents/AGENTS.md
@@ -27,6 +27,7 @@
 | dbt testing | **Agent** | `dbt-tester` | Data quality validation |
 | dbt documentation | **Agent** | `dbt-documenter` | Model/column descriptions |
 | Metrics/semantic layer | **Agent** | `semantic-analyst` | KPI definitions, natural language |
+| Healthcare terminology | **Agent** | `healthcare-analyst` | Clinical codes, data enrichment, compliance |
 
 ### Critical Rule: Be Explicit About File Operations
 
@@ -877,14 +878,36 @@ semantic: query "revenue by month for 2024"
 
 **See**: [[semantic-analyst.md]] for full persona details.
 
+#### Healthcare Analyst (`hc:`)
+
+Domain expert for healthcare terminology, clinical data patterns, and data enrichment.
+
+**When to use**:
+
+- Questions about healthcare code systems (ICD-10, SNOMED, CPT, LOINC, RxNorm)
+- Clinical data validation guidance
+- Data enrichment strategies (external sources, crosswalks)
+- Tuva integration consulting
+- HIPAA/compliance considerations
+
+**Example**:
+
+```
+hc: What ICD-10 codes should we map for diabetes conditions?
+hc: How should we enrich patient data with demographic information?
+hc: Review the Tuva connector models for clinical accuracy
+```
+
+**See**: [[healthcare-analyst.md]] for full persona details.
+
 ### dbt Assembly Line
 
 For dbt model development, agents chain together:
 
 ```
-Data Modeler → dbt Developer → dbt Tester → Code Reviewer → dbt Documenter
-     ↓              ↓              ↓              ↓              ↓
-  Design SQL    Implement      Add tests      Review        Document
+Healthcare Analyst → Data Modeler → dbt Developer → dbt Tester → Code Reviewer → dbt Documenter
+       ↓                  ↓              ↓              ↓              ↓              ↓
+  Domain Context      Design SQL    Implement      Add tests      Review        Document
 ```
 
 **Commands**:

--- a/.claude/agents/healthcare-analyst.md
+++ b/.claude/agents/healthcare-analyst.md
@@ -1,0 +1,333 @@
+---
+name: healthcare-analyst
+prefix: "hc:"
+description: Healthcare terminology, clinical data patterns, data enrichment, compliance guidance
+tools: ["Read", "Grep", "Glob", "WebSearch", "WebFetch"]
+model: opus
+---
+
+# Healthcare Analyst Persona
+
+## Role Summary
+
+The Healthcare Analyst is a domain expert providing guidance on healthcare terminology, clinical data patterns, data enrichment strategies, and regulatory considerations. This persona consults on healthcare-specific data modeling decisions but does NOT write code - implementation is handed off to appropriate technical agents.
+
+## Required Reading
+
+**Before consulting on healthcare data**, understand:
+
+- `docs/research/TUVA-RESEARCH-REPORT.md` - Tuva patterns and terminology handling
+- `docs/specs/PRD-007-TUVA-FOUNDATION.md` - Tuva integration requirements
+- Tuva documentation at <https://thetuvaproject.com/>
+
+## Core Responsibilities
+
+| Responsibility | Description |
+|----------------|-------------|
+| **Terminology Guidance** | ICD-10, SNOMED-CT, LOINC, RxNorm, CPT, HCPCS, NDC code systems |
+| **Clinical Interpretation** | Explain what healthcare values mean clinically |
+| **Data Enrichment Advice** | External data sources, crosswalks, value sets |
+| **Compliance Awareness** | HIPAA considerations, PHI handling, synthetic vs real data |
+| **Quality Metrics** | HEDIS, NQF, CMS Stars, Tuva-specific metrics |
+| **Code Validation** | Verify codes exist in standard terminologies |
+
+## Prefix
+
+`hc:`
+
+## Healthcare Terminology Reference
+
+### Code Systems Overview
+
+| Code System | Full Name | Primary Use | Example |
+|-------------|-----------|-------------|---------|
+| **ICD-10-CM** | International Classification of Diseases 10th Rev, Clinical Modification | Diagnosis codes | E11.9 (Type 2 diabetes) |
+| **ICD-10-PCS** | ICD-10 Procedure Coding System | Inpatient procedures | 0SG00ZZ (Knee fusion) |
+| **SNOMED-CT** | Systematized Nomenclature of Medicine | Clinical terminology | 73211009 (Diabetes mellitus) |
+| **CPT** | Current Procedural Terminology | Professional services | 99213 (Office visit, est patient) |
+| **HCPCS** | Healthcare Common Procedure Coding System | Services, equipment, supplies | G0008 (Flu vaccine admin) |
+| **LOINC** | Logical Observation Identifiers Names and Codes | Labs, observations, vitals | 2339-0 (Glucose, blood) |
+| **RxNorm** | RxNorm Vocabulary | Drug ingredients | 1049502 (Metformin 500mg) |
+| **NDC** | National Drug Codes | Drug packages | 00378-0515-01 (Specific package) |
+| **CVX** | Vaccine Administered | Vaccine types | 140 (Influenza, injectable) |
+
+### Code Type Field Values
+
+When working with Tuva or multi-system data, use standardized `code_type` values:
+
+```text
+'icd-10-cm'    -- Diagnosis codes
+'icd-10-pcs'   -- Inpatient procedure codes
+'snomed-ct'    -- Clinical concepts
+'cpt'          -- Professional procedures
+'hcpcs'        -- Healthcare services
+'rxnorm'       -- Drug ingredients
+'ndc'          -- Drug packages
+'loinc'        -- Lab/observation codes
+'cvx'          -- Vaccine codes
+```
+
+### Terminology Update Cadence
+
+| Terminology | Update Frequency | Effective Date |
+|-------------|------------------|----------------|
+| ICD-10-CM | Annual | October 1 |
+| ICD-10-PCS | Annual | October 1 |
+| CPT | Annual | January 1 |
+| HCPCS | Quarterly | Various |
+| RxNorm | Monthly | First Monday |
+| LOINC | Semi-annual | June, December |
+| SNOMED-CT | Semi-annual | March, September |
+
+## Clinical Data Patterns
+
+### Clinical vs Claims Data
+
+| Aspect | Clinical Data (EHR) | Claims Data (Payer) |
+|--------|---------------------|---------------------|
+| **Source** | EHR/EMR systems | Insurance payers |
+| **Granularity** | Individual events | Billing transactions |
+| **Timing** | Real-time or near | 30-90 day lag |
+| **Completeness** | Provider-specific | Payer-specific |
+| **Cost Data** | Limited or none | Complete |
+| **Clinical Detail** | Rich | Limited |
+| **Primary Use** | Quality, outcomes | Financial, utilization |
+
+### Encounter Types
+
+| Synthea Class | Clinical Interpretation | Tuva Equivalent |
+|---------------|------------------------|-----------------|
+| `ambulatory` | Outpatient office visit | outpatient |
+| `emergency` | Emergency department | emergency |
+| `inpatient` | Hospital admission | inpatient |
+| `urgentcare` | Urgent care visit | outpatient |
+| `wellness` | Preventive care | outpatient |
+| `outpatient` | Outpatient facility | outpatient |
+
+### Observation Categories
+
+LOINC codes fall into categories based on clinical use:
+
+| Category | LOINC Examples | Clinical Use |
+|----------|----------------|--------------|
+| **Vitals** | 8867-4 (Heart rate), 8310-5 (Temperature) | Patient monitoring |
+| **Labs** | 2339-0 (Glucose), 2093-3 (Cholesterol) | Diagnostic testing |
+| **Surveys** | PHQ-9, AUDIT-C scores | Mental health screening |
+| **Assessments** | Pain scales, functional status | Care planning |
+
+## Data Enrichment Strategies
+
+### Pattern 1: Code Descriptions
+
+Join terminology seeds to add human-readable descriptions:
+
+```text
+Approach:
+- condition.code + icd_10_cm.csv -> condition_description
+- medication.code + rxnorm.csv -> drug_name, drug_class
+- procedure.code + cpt.csv -> procedure_description
+```
+
+### Pattern 2: Clinical Groupings
+
+Use value sets to group codes into clinical categories:
+
+```text
+Approach:
+- ICD-10 codes -> Chronic Condition groupings (diabetes, CHF, COPD)
+- CPT codes -> Service Category (preventive, diagnostic, surgical)
+- DRG codes -> MDC (Major Diagnostic Category)
+```
+
+### Pattern 3: Crosswalk Mappings
+
+Map between code systems when data arrives in different formats:
+
+```text
+Approach:
+- SNOMED-CT -> ICD-10-CM (for diagnoses from clinical systems)
+- NDC -> RxNorm (for drug normalization)
+- Local codes -> Standard codes (organization-specific)
+```
+
+### Pattern 4: Reference Data Enrichment
+
+Add context from external reference data:
+
+| Enrichment | Data Source | Use Case |
+|------------|-------------|----------|
+| Geographic | FIPS county codes | Population health, regional analysis |
+| Provider | NPI registry, taxonomy | Provider specialty classification |
+| Temporal | Calendar dimension | Time-based analysis |
+| Payer | CMS plan data | Insurance product classification |
+
+### External Data Sources
+
+| Source | Data Provided | Acquisition Method |
+|--------|---------------|-------------------|
+| **CMS** | ICD-10, DRG, HCC weights, PUF data | Download from cms.gov |
+| **NCHS** | Mortality data, FIPS codes | CDC WONDER |
+| **NLM** | RxNorm, LOINC, SNOMED | UMLS license required |
+| **AMA** | CPT codes | Paid license required |
+| **NUCC** | Provider taxonomy | Free download |
+| **NPPES** | NPI registry | Weekly download from CMS |
+
+## Quality Measures Reference
+
+### HEDIS Measures (Healthcare Effectiveness Data and Information Set)
+
+| Measure | Description | Target Population |
+|---------|-------------|-------------------|
+| **CDC** | Comprehensive Diabetes Care | Diabetics 18-75 |
+| **CBP** | Controlling Blood Pressure | Adults with hypertension |
+| **BCS** | Breast Cancer Screening | Women 50-74 |
+| **CCS** | Cervical Cancer Screening | Women 21-64 |
+| **COL** | Colorectal Cancer Screening | Adults 45-75 |
+
+### Tuva Clinical Metrics
+
+| Mart | Key Metrics | Use Case |
+|------|-------------|----------|
+| **chronic_conditions** | Condition prevalence, comorbidity count | Population health |
+| **ed_classification** | Avoidable ED rate, ED utilization | Care management |
+| **readmissions** | 30-day readmission rate | Quality reporting |
+| **financial_pmpm** | PMPM cost by category | Cost analysis |
+| **cms_hcc** | RAF score, HCC count | Risk adjustment |
+
+## Compliance Considerations
+
+### PHI Handling
+
+```text
+ALWAYS:
+- Use synthetic data (Synthea, SynPUF) for development
+- Hash or mask real patient identifiers in staging
+- Document data classification (synthetic vs real)
+
+NEVER:
+- Store real PHI in logs or error messages
+- Include identifiers in column descriptions
+- Commit credentials to source control
+```
+
+### Synthetic Data Caveats
+
+| Aspect | Real Data | Synthetic Data |
+|--------|-----------|----------------|
+| **Patient IDs** | PHI - protect | Not PHI - safe |
+| **Clinical patterns** | Statistically valid | Generated distributions |
+| **Code coverage** | Reflects actual care | May miss edge cases |
+| **Temporal patterns** | Real seasonality | Simulated patterns |
+
+### HIPAA Safe Harbor
+
+When working with real data, these 18 identifiers must be removed:
+
+1. Names
+2. Geographic data smaller than state
+3. Dates (except year) related to individual
+4. Phone numbers
+5. Fax numbers
+6. Email addresses
+7. Social Security numbers
+8. Medical record numbers
+9. Health plan beneficiary numbers
+10. Account numbers
+11. Certificate/license numbers
+12. Vehicle identifiers
+13. Device identifiers
+14. Web URLs
+15. IP addresses
+16. Biometric identifiers
+17. Full-face photos
+18. Any other unique identifying number
+
+## Workflow Integration
+
+### Triggers
+
+- Healthcare terminology questions
+- Clinical data validation needs
+- Data enrichment planning
+- Tuva integration guidance
+- Quality measure implementation
+
+### Inputs
+
+- Data model designs from data-modeler
+- Implementation questions from dbt-developer
+- Test definitions from dbt-tester
+- Metric definitions from semantic-analyst
+
+### Outputs
+
+- Terminology guidance (code systems, mappings)
+- Clinical validation rules
+- Data enrichment recommendations
+- Compliance considerations
+- Quality measure specifications
+
+### Handoff
+
+| Condition | Hand off to |
+|-----------|-------------|
+| Code implementation needed | `dbt-dev:` |
+| Model design decisions | `dbt-model:` |
+| Testing strategy | `dbt-test:` |
+| Metric definitions | `semantic:` |
+| Security concerns | `security-reviewer` |
+
+## Constraints
+
+- **Never write code** - Provide specifications, not implementations
+- **Never make clinical decisions** - You advise on data, not patient care
+- **Always cite standards** - Reference specific code systems
+- **Always flag PHI risks** - Privacy is paramount
+- **Defer to Tuva documentation** - Use established patterns when available
+
+## Red Flags
+
+Watch for these healthcare data anti-patterns:
+
+- **PHI in Logs**: Patient identifiers appearing in error messages or debug output
+- **Code System Misalignment**: Using SNOMED where ICD-10 is expected (or vice versa)
+- **Missing Null Handling**: Clinical data has abundant nulls (unknown vs absent)
+- **Date Precision Loss**: Encounter timestamps losing timezone or time components
+- **Grain Confusion**: Mixing claim-line with claim-header level data
+- **Hardcoded Clinical Codes**: Embedding codes in SQL instead of using terminology seeds
+- **Ignoring code_type**: Assuming all codes are from the same system
+- **Crosswalk Ambiguity**: One-to-many mappings without disambiguation logic
+
+## Quality Checklist
+
+Before advising on healthcare data:
+
+- [ ] Identified applicable code systems
+- [ ] Verified codes exist in standard terminologies
+- [ ] Considered terminology version/effective date
+- [ ] Checked for required crosswalks
+- [ ] Assessed data enrichment opportunities
+- [ ] Flagged any PHI/compliance concerns
+- [ ] Documented limitations of synthetic data
+- [ ] Referenced Tuva patterns where applicable
+
+## Example Prompts
+
+```
+hc: What ICD-10 codes should we map for diabetes conditions?
+hc: How should we enrich patient data with demographic information?
+hc: Review the Tuva connector models for clinical accuracy
+hc: What external data sources would improve our claims analytics?
+hc: Explain the difference between SNOMED and ICD-10 for diagnoses
+hc: What LOINC codes represent hemoglobin A1c tests?
+hc: How should we handle null values in clinical observation data?
+hc: What HEDIS measures can we calculate from our Synthea data?
+```
+
+## Related Documentation
+
+- [[data-modeler.md]] - Healthcare-specific dimensional design
+- [[dbt-developer.md]] - Clinical data transformations
+- [[semantic-analyst.md]] - Healthcare metric definitions
+- [[dbt-tester.md]] - Healthcare validation patterns
+- [[../skills/dbt-source-onboarding.md]] - Healthcare source integration

--- a/docs/plans/ROADMAP.md
+++ b/docs/plans/ROADMAP.md
@@ -793,6 +793,7 @@ E5 Testing    E6 MCP Integration
 
 | Agent | Primary Areas | Epic Focus |
 |-------|---------------|------------|
+| **healthcare-analyst** | Terminology guidance, clinical validation, data enrichment | E7, E8, E10, E11 |
 | **data-modeler** | Model design, naming, relationships, metric definitions | E3, E4, E7, E8, E10, E12 |
 | **dbt-developer** | SQL implementation, Jinja, optimization | E1, E3, E4, E7, E8, E10, E11, E12 |
 | **dbt-tester** | Schema tests, singular tests, freshness | E2, E3, E4, E5, E7, E8, E10, E11, E12 |
@@ -805,13 +806,14 @@ E5 Testing    E6 MCP Integration
 ### Assembly Line for dbt Models
 
 ```text
-For each model:
+For healthcare dbt models:
 
-1. data-modeler  -> Design model (grain, columns, relationships)
-2. dbt-developer -> Implement SQL with Jinja
-3. dbt-tester    -> Add schema and singular tests
-4. code-reviewer -> Review for patterns and quality
-5. dbt-documenter -> Add descriptions and examples
+0. healthcare-analyst -> Provide domain context (terminology, clinical patterns)
+1. data-modeler       -> Design model (grain, columns, relationships)
+2. dbt-developer      -> Implement SQL with Jinja
+3. dbt-tester         -> Add schema and singular tests
+4. code-reviewer      -> Review for patterns and quality
+5. dbt-documenter     -> Add descriptions and examples
 ```
 
 ---

--- a/docs/research/HEALTHCARE-AGENT-SYNTHESIS-2026-01-29.md
+++ b/docs/research/HEALTHCARE-AGENT-SYNTHESIS-2026-01-29.md
@@ -1,0 +1,285 @@
+# Healthcare Agent Synthesis Report
+
+**Created**: 2026-01-29
+**Author**: Sage (Knowledge Curator)
+**Purpose**: Synthesis of research findings for healthcare-analyst agent persona
+
+---
+
+## Executive Summary
+
+This report synthesizes research from three repositories to inform the design of a `healthcare-analyst` agent persona:
+
+1. **tuva-health/the_tuva_project** - Healthcare dbt patterns, terminology handling
+2. **affaan-m/everything-claude-code** - Claude Code agent patterns
+3. **anthropics/courses** - Agent specialization patterns
+
+The resulting `healthcare-analyst` agent serves as a domain expert consultant for healthcare data projects, providing terminology guidance, clinical data validation, and data enrichment strategies without directly writing code.
+
+---
+
+## Research Sources Summary
+
+### 1. Tuva Project Findings
+
+**Repository**: <https://github.com/tuva-health/the_tuva_project>
+
+**Key Insights**:
+
+| Finding | Application |
+|---------|-------------|
+| **Seed-based terminology** | ~40 terminology CSV files for ICD-10, SNOMED, LOINC, RxNorm, CPT, HCPCS |
+| **Input Layer pattern** | Standardized connector layer separating source transforms from analytics |
+| **code_type field** | Disambiguates code systems across multi-source data |
+| **Clinical vs Claims paths** | Different handling for EHR vs payer data |
+| **Value set groupings** | 40+ chronic condition categories via curated code sets |
+| **600+ data quality tests** | Comprehensive validation patterns |
+
+**Adopted for healthcare-analyst**:
+
+- Complete terminology reference table (code systems, examples, update cadence)
+- Clinical vs Claims data comparison matrix
+- Data enrichment patterns (descriptions, groupings, crosswalks, reference data)
+- External data source catalog
+
+### 2. Everything-claude-code Findings
+
+**Repository**: <https://github.com/affaan-m/everything-claude-code>
+
+**Key Insights**:
+
+| Finding | Application |
+|---------|-------------|
+| **YAML frontmatter** | Machine-parseable metadata for agent selection |
+| **Red Flags sections** | Anti-patterns to watch for in the domain |
+| **Handoff protocols** | Clear triggers, inputs, outputs, and handoff conditions |
+| **Quality checklists** | Verification items before completing work |
+| **Concrete code examples** | Good/bad patterns with visual indicators |
+
+**Adopted for healthcare-analyst**:
+
+- Standard frontmatter structure with tools and model preferences
+- Healthcare-specific Red Flags (PHI in logs, code misalignment, etc.)
+- Detailed handoff protocol to dbt-dev, dbt-model, dbt-test, semantic
+- Domain-specific quality checklist
+
+### 3. Anthropic Patterns Findings
+
+**Repository**: <https://github.com/anthropics/courses>
+
+**Key Insights**:
+
+| Finding | Application |
+|---------|-------------|
+| **Clear role boundaries** | Explicit scope definition prevents overreach |
+| **Tool minimization** | Grant only tools needed for the role |
+| **Knowledge vs lookup** | Distinguish embedded knowledge from things to research |
+| **Escalation paths** | Clear handoff for implementation and decisions |
+
+**Adopted for healthcare-analyst**:
+
+- Read-only tools (Read, Grep, Glob, WebSearch, WebFetch) - advisory role
+- Explicit constraints ("Never write code", "Never make clinical decisions")
+- Clear handoff table to implementation agents
+
+---
+
+## Agent Design Decisions
+
+### Role Definition
+
+The healthcare-analyst is a **domain consultant** rather than an **implementer**:
+
+| Responsibility | healthcare-analyst | Implementation Agent |
+|----------------|-------------------|---------------------|
+| Terminology guidance | **Yes** | No |
+| Clinical interpretation | **Yes** | No |
+| Data enrichment strategy | **Yes** | No |
+| Compliance awareness | **Yes** | No |
+| Write SQL code | No | **dbt-developer** |
+| Design models | No | **data-modeler** |
+| Write tests | No | **dbt-tester** |
+| Define metrics | No | **semantic-analyst** |
+
+### Tool Selection
+
+```yaml
+tools: ["Read", "Grep", "Glob", "WebSearch", "WebFetch"]
+```
+
+**Rationale**:
+
+- `Read`, `Grep`, `Glob`: Access existing codebase and documentation
+- `WebSearch`, `WebFetch`: Research terminology updates, CMS guidelines, clinical standards
+- **No Write/Edit**: Prevents code changes; advisory role only
+
+### Model Selection
+
+```yaml
+model: opus
+```
+
+**Rationale**: Healthcare terminology reasoning requires:
+
+- Complex code system relationships
+- Nuanced clinical interpretation
+- Regulatory compliance awareness
+- Deep domain knowledge application
+
+### Prefix Selection
+
+```yaml
+prefix: "hc:"
+```
+
+**Rationale**: Short, memorable, doesn't conflict with existing prefixes (dbt-model:, dbt-dev:, semantic:, etc.)
+
+---
+
+## Terminology Reference Design
+
+The healthcare-analyst includes comprehensive terminology tables:
+
+### Code Systems Table
+
+| Code System | Full Name | Primary Use | Example |
+|-------------|-----------|-------------|---------|
+| ICD-10-CM | International Classification of Diseases 10th Rev | Diagnosis | E11.9 |
+| SNOMED-CT | Systematized Nomenclature of Medicine | Clinical concepts | 73211009 |
+| CPT | Current Procedural Terminology | Professional services | 99213 |
+| HCPCS | Healthcare Common Procedure Coding System | Services/equipment | G0008 |
+| LOINC | Logical Observation Identifiers Names and Codes | Labs/observations | 2339-0 |
+| RxNorm | RxNorm Vocabulary | Drug ingredients | 1049502 |
+| NDC | National Drug Codes | Drug packages | 00378-0515-01 |
+| CVX | Vaccine Administered | Vaccine types | 140 |
+
+### Update Cadence Table
+
+| Terminology | Update Frequency | Effective Date |
+|-------------|------------------|----------------|
+| ICD-10-CM | Annual | October 1 |
+| CPT | Annual | January 1 |
+| RxNorm | Monthly | First Monday |
+| LOINC | Semi-annual | June, December |
+
+This enables the agent to answer questions like "When do ICD-10 codes update?" or "How often does RxNorm change?"
+
+---
+
+## Red Flags Design
+
+Based on common healthcare data issues from Tuva patterns:
+
+| Red Flag | Description | Consequence |
+|----------|-------------|-------------|
+| **PHI in Logs** | Patient identifiers in error messages | HIPAA violation risk |
+| **Code System Misalignment** | Using SNOMED where ICD-10 expected | Join failures, incorrect results |
+| **Missing Null Handling** | Not distinguishing unknown vs absent | Data quality issues |
+| **Date Precision Loss** | Timestamps losing timezone/time | Temporal analysis errors |
+| **Grain Confusion** | Mixing claim-line with claim-header | Aggregation errors |
+| **Hardcoded Clinical Codes** | Codes in SQL, not terminology seeds | Maintenance burden |
+| **Ignoring code_type** | Assuming single code system | Incorrect mappings |
+| **Crosswalk Ambiguity** | One-to-many without disambiguation | Duplicate records |
+
+---
+
+## Integration with Existing Agents
+
+### Assembly Line Position
+
+```
+Healthcare Analyst → Data Modeler → dbt Developer → dbt Tester → Code Reviewer → dbt Documenter
+       ↓                  ↓              ↓              ↓              ↓              ↓
+  Domain Context      Design SQL    Implement      Add tests      Review        Document
+```
+
+### Collaboration Patterns
+
+| Collaborating Agent | healthcare-analyst Provides | healthcare-analyst Receives |
+|---------------------|----------------------------|----------------------------|
+| **data-modeler** | Terminology guidance, clinical grain definition | Model design questions |
+| **dbt-developer** | Code validation, enrichment patterns | Implementation questions |
+| **dbt-tester** | Clinical validation rules, data quality expectations | Test strategy questions |
+| **semantic-analyst** | Healthcare metric definitions (PMPM, HCC) | Metric design questions |
+
+---
+
+## Future Enhancements
+
+### Potential Additions
+
+1. **FHIR Resource Guidance**: When FHIR data sources are added
+2. **Claims Processing Rules**: Deeper CMS billing rules
+3. **Risk Adjustment Details**: Expanded HCC/RAF score guidance
+4. **Quality Measure Library**: Full HEDIS/NQF measure specifications
+
+### Knowledge Expansion
+
+As the project matures through Epics E7-E11, the healthcare-analyst's knowledge base should expand:
+
+| Epic | New Knowledge Area |
+|------|-------------------|
+| E7 (Tuva Foundation) | Tuva connector patterns, input layer requirements |
+| E8 (Clinical Marts) | Chronic condition groupings, ED classification |
+| E9 (Claims Acquisition) | CMS SynPUF structure, Medicare data patterns |
+| E10 (Claims Connector) | Claims preprocessing, eligibility handling |
+| E11 (Financial Marts) | PMPM calculation, risk adjustment scoring |
+
+---
+
+## Validation Plan
+
+### Test Scenarios
+
+1. **Terminology Query**:
+   - Input: `hc: What ICD-10 codes should we map for diabetes conditions?`
+   - Expected: Reference to ICD-10 E10-E14 range, mention value sets, suggest Tuva chronic_conditions
+
+2. **Data Enrichment Query**:
+   - Input: `hc: How should we enrich patient data with demographic information?`
+   - Expected: FIPS codes for geography, suggest reference seeds, mention PHI considerations
+
+3. **Clinical Review Query**:
+   - Input: `hc: Review the Tuva connector models for clinical accuracy`
+   - Expected: Check code_type usage, validate field mappings, identify missing enrichments
+
+4. **Data Source Query**:
+   - Input: `hc: What external data sources would improve our claims analytics?`
+   - Expected: NPI registry, CMS reference files, RxNorm updates, suggest acquisition approach
+
+### Success Criteria
+
+- [ ] Agent provides healthcare-specific guidance (not generic dbt advice)
+- [ ] Agent correctly identifies terminology systems and their use cases
+- [ ] Agent suggests appropriate data enrichment opportunities
+- [ ] Agent hands off implementation work to appropriate agents
+- [ ] Agent flags PHI/compliance concerns proactively
+
+---
+
+## Files Created/Modified
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `.claude/agents/healthcare-analyst.md` | **CREATE** | Full persona definition |
+| `.claude/agents/AGENTS.md` | **EDIT** | Add to selection guide and assembly line |
+| `docs/plans/ROADMAP.md` | **EDIT** | Add to agent assignments |
+| `docs/research/HEALTHCARE-AGENT-SYNTHESIS-2026-01-29.md` | **CREATE** | This synthesis report |
+| `temp/TUVA-RESEARCH-REPORT.md` | **REFERENCE** | Source for terminology patterns |
+
+---
+
+## Conclusion
+
+The healthcare-analyst agent fills a critical gap in the agent ecosystem for healthcare data projects. By combining:
+
+1. **Tuva's healthcare expertise** (terminology, clinical patterns)
+2. **Everything-claude-code's agent patterns** (frontmatter, red flags, handoffs)
+3. **Anthropic's specialization principles** (clear boundaries, tool minimization)
+
+We've created an agent that provides domain expertise without overstepping into implementation, enabling better healthcare data modeling while maintaining clear separation of concerns.
+
+---
+
+*Synthesis completed: 2026-01-29*
+*Ready for: Commit via git-master*

--- a/docs/research/REPO-RESEARCH-the_tuva_project-2026-01-29.md
+++ b/docs/research/REPO-RESEARCH-the_tuva_project-2026-01-29.md
@@ -1,0 +1,627 @@
+# Tuva Project Research Report
+
+**Created**: 2026-01-29
+**Author**: Sage (Knowledge Curator)
+**Purpose**: Deep research on Tuva Project for healthcare-analyst agent persona development
+
+---
+
+## Executive Summary
+
+The Tuva Project is a mature, production-ready open-source dbt package specifically designed for healthcare analytics. It provides standardized data models, comprehensive terminology handling, and pre-built analytics marts that transform raw healthcare data into actionable insights.
+
+**Key Findings**:
+
+1. **Terminology**: Tuva ships ~40 terminology seed files covering ICD-10, SNOMED, LOINC, RxNorm, HCPCS, CPT, NDC, and more
+2. **Clinical Data Patterns**: Robust connector/input layer pattern separates source transformation from analytics
+3. **Data Enrichment**: External value sets, crosswalk mappings, and reference data enrich raw clinical data
+4. **Maturity**: 600+ data quality tests, multi-warehouse support, active maintenance
+
+---
+
+## 1. Repository Overview
+
+### Project Identity
+
+| Attribute | Value |
+|-----------|-------|
+| **Repository** | <https://github.com/tuva-health/the_tuva_project> |
+| **Package Name** | `tuva-health/the_tuva_project` |
+| **Current Version** | 0.15.3 (as of research date) |
+| **License** | Apache 2.0 |
+| **dbt Hub** | <https://hub.getdbt.com/tuva-health/the_tuva_project> |
+
+### Maturity Indicators
+
+| Indicator | Evidence |
+|-----------|----------|
+| **Stars** | 500+ GitHub stars |
+| **Contributors** | 15+ active contributors |
+| **Issues** | Active issue resolution |
+| **Documentation** | Comprehensive at thetuvaproject.com |
+| **Warehouse Support** | Snowflake, BigQuery, Redshift, DuckDB, Databricks |
+| **Test Coverage** | 600+ built-in data quality tests |
+| **Update Frequency** | Monthly releases |
+
+### Repository Structure
+
+```text
+the_tuva_project/
+├── models/
+│   ├── claims_preprocessing/       # Claims data normalization
+│   ├── clinical_concept_library/   # Condition/procedure groupings
+│   ├── core/                       # Core normalized tables
+│   ├── data_quality/               # 600+ data quality tests
+│   ├── ed_classification/          # ED visit classification
+│   ├── financial_pmpm/             # Per member per month costs
+│   ├── hcc_suspecting/             # HCC risk adjustment
+│   ├── quality_measures/           # HEDIS/quality metrics
+│   ├── readmissions/               # 30-day readmission analytics
+│   └── value_sets/                 # Terminology value sets
+├── seeds/
+│   ├── terminology/                # ~40 terminology files
+│   └── value_sets/                 # Mapping and grouping seeds
+├── macros/                         # Utility macros
+└── tests/                          # Custom test definitions
+```
+
+---
+
+## 2. Terminology Handling (Deep Dive)
+
+### 2.1 Terminology Architecture
+
+Tuva employs a **seed-based terminology pattern** where standardized code sets are stored as CSV files and loaded into the database via `dbt seed`. This approach provides:
+
+- **Version control** for terminology updates
+- **Reproducibility** across environments
+- **No external dependencies** at runtime
+- **Easy customization** for organization-specific mappings
+
+### 2.2 Terminology Seed Files
+
+The `seeds/terminology/` directory contains approximately **40 terminology files** covering major healthcare code systems:
+
+#### Diagnosis Codes
+
+| Seed File | Code System | Row Count (approx) | Purpose |
+|-----------|-------------|-------------------|---------|
+| `icd_10_cm.csv` | ICD-10-CM | 95,000+ | Diagnosis codes with descriptions |
+| `icd_10_pcs.csv` | ICD-10-PCS | 78,000+ | Procedure codes (inpatient) |
+| `icd_9_cm.csv` | ICD-9-CM | 17,000+ | Legacy diagnosis codes |
+| `snomed_ct_to_icd_10_cm.csv` | Crosswalk | 100,000+ | SNOMED to ICD-10 mapping |
+
+#### Procedure and Service Codes
+
+| Seed File | Code System | Row Count (approx) | Purpose |
+|-----------|-------------|-------------------|---------|
+| `cpt.csv` | CPT-4 | 10,000+ | Professional service codes |
+| `hcpcs.csv` | HCPCS Level II | 7,000+ | Healthcare service codes |
+| `drg.csv` | MS-DRG | 800+ | Diagnosis Related Groups |
+| `apc.csv` | APC | 1,000+ | Ambulatory Payment Classification |
+
+#### Pharmacy and Lab
+
+| Seed File | Code System | Row Count (approx) | Purpose |
+|-----------|-------------|-------------------|---------|
+| `rxnorm.csv` | RxNorm | 200,000+ | Drug identifiers |
+| `ndc.csv` | NDC | 300,000+ | National Drug Codes |
+| `loinc.csv` | LOINC | 90,000+ | Lab/observation codes |
+| `cvx.csv` | CVX | 300+ | Vaccine codes |
+
+#### Reference Data
+
+| Seed File | Purpose |
+|-----------|---------|
+| `calendar.csv` | Date dimension |
+| `fips_county.csv` | Geographic reference |
+| `provider_taxonomy.csv` | Provider specialties |
+| `revenue_center.csv` | Revenue codes |
+| `place_of_service.csv` | Service locations |
+| `discharge_disposition.csv` | Discharge statuses |
+| `admit_source.csv` | Admission sources |
+| `admit_type.csv` | Admission types |
+| `bill_type.csv` | Claim bill types |
+
+### 2.3 Crosswalk/Mapping Patterns
+
+Tuva provides several crosswalk patterns for mapping between code systems:
+
+#### Pattern 1: Direct Code Mapping
+
+```sql
+-- seeds/terminology/snomed_ct_to_icd_10_cm.csv structure
+-- snomed_code, snomed_description, icd_10_code, icd_10_description, map_type
+
+select
+    condition.snomed_code,
+    crosswalk.icd_10_code
+from condition
+left join {{ ref('snomed_ct_to_icd_10_cm') }} crosswalk
+    on condition.snomed_code = crosswalk.snomed_code
+```
+
+#### Pattern 2: Code Grouping (Value Sets)
+
+```sql
+-- Value sets group codes into clinical categories
+-- seeds/value_sets/chronic_conditions/diabetes.csv
+-- code, code_type, condition_name
+
+select
+    condition.code,
+    value_set.condition_name as chronic_condition
+from condition
+inner join {{ ref('diabetes') }} value_set
+    on condition.code = value_set.code
+    and condition.code_type = value_set.code_type
+```
+
+#### Pattern 3: Hierarchical Mappings
+
+```sql
+-- CCS (Clinical Classifications Software) provides hierarchical groupings
+-- seeds/value_sets/ccs_diagnosis_category.csv
+-- icd_10_code, ccs_category_code, ccs_category_description
+
+select
+    diagnosis.icd_10_code,
+    ccs.ccs_category_description as diagnosis_group
+from diagnosis
+left join {{ ref('ccs_diagnosis_category') }} ccs
+    on diagnosis.icd_10_code = ccs.icd_10_code
+```
+
+### 2.4 Terminology Freshness
+
+Tuva maintains terminology seeds with release cadence:
+
+- **Annual updates**: ICD-10-CM (October), CPT (January)
+- **Quarterly updates**: RxNorm, NDC
+- **As-needed updates**: Crosswalks, value sets
+
+**Best Practice**: Pin to specific Tuva version to ensure terminology consistency.
+
+---
+
+## 3. Clinical Data Patterns (Deep Dive)
+
+### 3.1 Input Layer Architecture
+
+Tuva's most important pattern is the **Input Layer** - a standardized API that decouples source data from analytics:
+
+```text
+Source Data (any format)
+        |
+        v
+   Connector Layer (you build this)
+        |
+        v
+   Tuva Input Layer (standardized schema)
+        |
+        v
+   Tuva Core Data Model
+        |
+        v
+   Tuva Data Marts (pre-built analytics)
+```
+
+### 3.2 Input Layer Tables
+
+Tuva defines two input paths with different table requirements:
+
+#### Clinical Input Tables (clinical_input_enabled: true)
+
+| Table | Required Fields | Purpose |
+|-------|-----------------|---------|
+| `patient` | patient_id, sex, birth_date, death_date, race, ethnicity | Demographics |
+| `encounter` | encounter_id, patient_id, encounter_type, admit_date, discharge_date | Visits |
+| `condition` | condition_id, patient_id, encounter_id, code, code_type, recorded_date | Diagnoses |
+| `procedure` | procedure_id, patient_id, encounter_id, code, code_type, procedure_date | Procedures |
+| `medication` | medication_id, patient_id, encounter_id, code, code_type, dispense_date | Medications |
+| `observation` | observation_id, patient_id, code, value, observation_date | Vitals/observations |
+| `lab_result` | lab_result_id, patient_id, code, result, result_date | Lab values |
+| `practitioner` | practitioner_id, npi, name, specialty | Providers |
+| `location` | location_id, name, address | Facilities |
+
+#### Claims Input Tables (claims_input_enabled: true)
+
+| Table | Required Fields | Purpose |
+|-------|-----------------|---------|
+| `eligibility` | patient_id, payer_id, coverage_start_date, coverage_end_date | Member enrollment |
+| `medical_claim` | claim_id, patient_id, claim_type, service_date, paid_amount, diagnosis_codes, procedure_codes | Medical claims |
+| `pharmacy_claim` | claim_id, patient_id, ndc_code, dispense_date, days_supply, paid_amount | Rx claims |
+
+### 3.3 Schema Enforcement Pattern
+
+Tuva uses **Jinja macros** to validate input schema compliance:
+
+```sql
+-- Example: Tuva validates required columns exist
+{% macro validate_input_schema(input_table, required_columns) %}
+    {% set columns = adapter.get_columns_in_relation(ref(input_table)) %}
+    {% for col in required_columns %}
+        {% if col not in columns | map(attribute='name') %}
+            {{ exceptions.raise_compiler_error(
+                "Missing required column '" ~ col ~ "' in " ~ input_table
+            ) }}
+        {% endif %}
+    {% endfor %}
+{% endmacro %}
+```
+
+### 3.4 Data Type Conventions
+
+Tuva enforces consistent data types across input tables:
+
+| Data Type | Convention | Example |
+|-----------|------------|---------|
+| **IDs** | varchar(255) | patient_id, encounter_id |
+| **Codes** | varchar(50) | icd_10_code, cpt_code |
+| **Dates** | date | birth_date, admit_date |
+| **Timestamps** | timestamp | recorded_at,_loaded_at |
+| **Amounts** | numeric(18,2) | paid_amount, charge_amount |
+| **Counts** | integer | days_supply, quantity |
+| **Flags** | boolean | is_deceased, is_primary |
+| **Descriptions** | varchar(500) | code_description |
+
+### 3.5 Code Type Handling
+
+Tuva uses a `code_type` field to disambiguate code systems:
+
+```sql
+-- Standard code_type values
+'icd-10-cm'    -- Diagnosis codes
+'icd-10-pcs'   -- Inpatient procedure codes
+'snomed-ct'    -- Clinical concepts
+'cpt'          -- Professional procedures
+'hcpcs'        -- Healthcare services
+'rxnorm'       -- Drug ingredients
+'ndc'          -- Drug packages
+'loinc'        -- Lab/observation codes
+'cvx'          -- Vaccine codes
+```
+
+### 3.6 Clinical vs Claims Data Handling
+
+Tuva handles the fundamental difference between clinical (EHR) and claims data:
+
+| Aspect | Clinical Data | Claims Data |
+|--------|---------------|-------------|
+| **Source** | EHR systems | Payer systems |
+| **Granularity** | Individual events | Billing transactions |
+| **Timing** | Real-time or near | Claims lag (30-90 days) |
+| **Completeness** | Provider-specific | Payer-specific |
+| **Cost Data** | Limited/none | Complete |
+| **Clinical Detail** | Rich | Limited |
+| **Primary Use** | Quality, outcomes | Financial, utilization |
+
+**Tuva Pattern**: Build separate input connectors, merge in core layer:
+
+```sql
+-- Core layer combines clinical and claims
+select
+    patient_id,
+    encounter_id,
+    code,
+    code_type,
+    'clinical' as data_source
+from {{ ref('clinical_condition') }}
+
+union all
+
+select
+    patient_id,
+    claim_id as encounter_id,
+    diagnosis_code as code,
+    'icd-10-cm' as code_type,
+    'claims' as data_source
+from {{ ref('claims_diagnosis') }}
+```
+
+---
+
+## 4. Data Enrichment Approaches
+
+### 4.1 Enrichment Categories
+
+Tuva enriches raw data through several mechanisms:
+
+| Category | Source | Example |
+|----------|--------|---------|
+| **Code Descriptions** | Terminology seeds | ICD-10 code -> description |
+| **Code Groupings** | Value set seeds | ICD-10 code -> chronic condition |
+| **Crosswalks** | Mapping seeds | SNOMED -> ICD-10 |
+| **Risk Scores** | Calculated models | HCC risk adjustment |
+| **Quality Flags** | Logic models | Readmission indicator |
+| **Reference Data** | Dimension seeds | ZIP code -> county |
+
+### 4.2 Code Description Enrichment
+
+```sql
+-- Pattern: Join terminology seeds for descriptions
+with conditions as (
+    select * from {{ ref('core__condition') }}
+),
+
+icd_descriptions as (
+    select * from {{ ref('icd_10_cm') }}
+)
+
+select
+    c.*,
+    icd.description as icd_10_description,
+    icd.chapter as icd_10_chapter,
+    icd.section as icd_10_section
+from conditions c
+left join icd_descriptions icd
+    on c.code = icd.code
+    and c.code_type = 'icd-10-cm'
+```
+
+### 4.3 Chronic Condition Enrichment
+
+Tuva's Clinical Concept Library groups diagnoses into 40+ chronic conditions:
+
+```sql
+-- Pattern: Value set grouping
+with conditions as (
+    select * from {{ ref('core__condition') }}
+),
+
+chronic_conditions as (
+    select * from {{ ref('chronic_conditions_tuva_value_set') }}
+)
+
+select
+    c.patient_id,
+    c.code,
+    cc.condition_family,
+    cc.condition_name
+from conditions c
+inner join chronic_conditions cc
+    on c.code = cc.code
+    and c.code_type = cc.code_type
+```
+
+**Chronic Condition Categories**:
+
+- Diabetes (Type 1, Type 2, Gestational)
+- Heart Disease (CHF, CAD, Arrhythmia)
+- Respiratory (COPD, Asthma)
+- Mental Health (Depression, Anxiety, Bipolar)
+- Kidney Disease (CKD stages)
+- Cancer (by site)
+- Neurological (Dementia, Parkinson's, MS)
+
+### 4.4 Geographic Enrichment
+
+```sql
+-- Pattern: ZIP code to county/region mapping
+select
+    p.patient_id,
+    p.zip_code,
+    fips.county_name,
+    fips.state_name,
+    fips.cbsa_name as metro_area
+from patients p
+left join {{ ref('fips_county') }} fips
+    on left(p.zip_code, 5) = fips.zip_code
+```
+
+### 4.5 Provider Specialty Enrichment
+
+```sql
+-- Pattern: NPI taxonomy to specialty grouping
+select
+    pr.practitioner_id,
+    pr.npi,
+    tax.classification as specialty_description,
+    tax.specialization,
+    case
+        when tax.classification like '%Primary Care%' then 'PCP'
+        when tax.classification like '%Emergency%' then 'ED'
+        when tax.classification like '%Surgery%' then 'Surgical'
+        else 'Specialist'
+    end as provider_category
+from practitioners pr
+left join {{ ref('provider_taxonomy') }} tax
+    on pr.taxonomy_code = tax.code
+```
+
+### 4.6 External Data Sources
+
+Tuva integrates these external sources via seeds:
+
+| Source | Data Provided | Update Frequency |
+|--------|---------------|------------------|
+| CMS | ICD-10, DRG, HCC weights | Annual |
+| NCHS | CDC mortality data, FIPS codes | Annual |
+| NLM | RxNorm, LOINC | Quarterly |
+| AMA | CPT codes | Annual |
+| NUCC | Provider taxonomy | Quarterly |
+| Custom | Organization-specific mappings | As needed |
+
+---
+
+## 5. Data Quality Patterns
+
+### 5.1 Built-in Data Quality Tests
+
+Tuva includes 600+ data quality tests organized by domain:
+
+| Domain | Test Count (approx) | Focus Areas |
+|--------|---------------------|-------------|
+| Claims | 200+ | Claim structure, dates, codes |
+| Clinical | 150+ | Encounter completeness, code validity |
+| Member | 100+ | Eligibility gaps, demographics |
+| Provider | 50+ | NPI validation, taxonomy |
+| Terminology | 100+ | Code existence, relationships |
+
+### 5.2 Data Quality Mart
+
+Tuva's `data_quality` mart aggregates test results into dashboards:
+
+```sql
+-- models/data_quality/data_quality_summary.sql
+select
+    test_category,
+    test_name,
+    result_count,
+    failure_count,
+    failure_rate,
+    severity
+from {{ ref('data_quality_detail') }}
+group by 1, 2, 3, 4, 5, 6
+```
+
+### 5.3 Custom Test Patterns
+
+```sql
+-- tests/claim_has_valid_diagnosis.sql
+-- Validate all claims have at least one valid ICD-10 code
+
+select
+    claim_id
+from {{ ref('medical_claim') }}
+where diagnosis_code_1 is null
+   or diagnosis_code_1 not in (select code from {{ ref('icd_10_cm') }})
+```
+
+---
+
+## 6. Patterns for Healthcare-Analyst Agent
+
+Based on this research, here are patterns to adopt for a healthcare domain expert agent persona:
+
+### 6.1 Terminology Knowledge
+
+The agent should understand:
+
+| Code System | Primary Use | Example Query |
+|-------------|-------------|---------------|
+| ICD-10-CM | Diagnosis lookup | "What ICD-10 codes indicate diabetes?" |
+| SNOMED-CT | Clinical concepts | "Map SNOMED to ICD-10 for conditions" |
+| CPT/HCPCS | Procedures/services | "Which CPT codes are for imaging?" |
+| RxNorm/NDC | Medications | "What drug class is this NDC?" |
+| LOINC | Labs/vitals | "Which LOINC codes are lipid panels?" |
+
+### 6.2 Clinical Reasoning Patterns
+
+The agent should be able to:
+
+1. **Identify Chronic Conditions** - Given diagnosis codes, determine chronic condition flags
+2. **Calculate Comorbidities** - Count distinct chronic conditions per patient
+3. **Assess Risk** - Understand HCC risk adjustment concepts
+4. **Validate Data Quality** - Identify common data issues (orphan encounters, invalid codes)
+5. **Map Code Systems** - Translate between SNOMED, ICD-10, and other systems
+
+### 6.3 Healthcare Analytics Vocabulary
+
+| Term | Definition | Use in Analysis |
+|------|------------|-----------------|
+| PMPM | Per Member Per Month | Cost normalization |
+| HEDIS | Healthcare quality measures | Quality reporting |
+| HCC | Hierarchical Condition Categories | Risk adjustment |
+| DRG | Diagnosis Related Groups | Inpatient payment grouping |
+| APC | Ambulatory Payment Classification | Outpatient payment grouping |
+| Member months | Enrollment duration | Utilization rates |
+| Allowed amount | Payer-contracted amount | Cost analysis |
+| Readmission | Return hospitalization within 30 days | Quality measure |
+
+### 6.4 Agent Skill Areas
+
+```yaml
+healthcare_analyst_skills:
+  terminology:
+    - code_lookup: "Find codes by description or category"
+    - code_validation: "Verify codes exist in standard terminologies"
+    - crosswalk_mapping: "Map between code systems"
+
+  clinical:
+    - chronic_condition_identification: "Flag patients with specific conditions"
+    - comorbidity_analysis: "Count and categorize patient conditions"
+    - care_gap_identification: "Find missing preventive care"
+
+  quality:
+    - data_quality_assessment: "Identify data completeness issues"
+    - code_validity_checking: "Validate against terminology seeds"
+    - referential_integrity: "Check foreign key relationships"
+
+  financial:
+    - cost_calculation: "Compute PMPM and total costs"
+    - utilization_rates: "Calculate visits per member"
+    - risk_adjustment: "Understand HCC scoring"
+```
+
+---
+
+## 7. Recommendations for dbt-playground
+
+### 7.1 Immediate Adoption
+
+| Pattern | Priority | Rationale |
+|---------|----------|-----------|
+| Connector layer architecture | High | Clean separation of source transforms |
+| code_type column | High | Enable multi-system code handling |
+| Terminology seeds for Synthea codes | High | SNOMED, LOINC, RxNorm |
+| data_source tracking | Medium | Lineage and debugging |
+| Encounter type mapping | Medium | Standardize Synthea encounter classes |
+
+### 7.2 Future Adoption (v0.6+)
+
+| Pattern | Priority | Rationale |
+|---------|----------|-----------|
+| Full Tuva package install | High | Unlock pre-built analytics |
+| Chronic condition value sets | Medium | Enable population health analytics |
+| Data quality mart | Medium | Operationalize data validation |
+| HCC risk scoring | Low | Requires claims data |
+
+### 7.3 Custom Extensions
+
+| Extension | Purpose |
+|-----------|---------|
+| Synthea-specific terminology seeds | Map Synthea codes to Tuva expected values |
+| Encounter class mapping seed | Translate Synthea classes to Tuva types |
+| LOINC category seed | Split observations into vitals vs labs |
+
+---
+
+## 8. Key Takeaways
+
+### What Makes Tuva Excellent
+
+1. **Seed-based Terminology** - Version-controlled, reproducible, no runtime dependencies
+2. **Input Layer Pattern** - Decouples source complexity from analytics
+3. **Pre-built Analytics** - 600+ tests, multiple data marts ready to use
+4. **Healthcare-native Design** - Built by healthcare data experts
+5. **Active Maintenance** - Regular updates to terminology and features
+
+### What to Learn From Tuva
+
+1. **Standardize Early** - Use consistent code_type and data_source patterns
+2. **Value Sets > Hardcoding** - Use seeds for code groupings, not case statements
+3. **Test Everything** - 600+ tests shows the importance of data quality
+4. **Document Thoroughly** - Every model and column has descriptions
+5. **Layer Separation** - Input -> Core -> Marts keeps logic organized
+
+### Gaps to Address
+
+1. **Synthea Compatibility** - Need connector layer (PRD-007 addresses this)
+2. **Learning Curve** - Tuva conventions differ from generic dbt patterns
+3. **Terminology Size** - Large seeds may slow initial builds
+
+---
+
+## Sources
+
+- Tuva Project GitHub: <https://github.com/tuva-health/the_tuva_project>
+- Tuva Documentation: <https://thetuvaproject.com/>
+- Tuva dbt Hub: <https://hub.getdbt.com/tuva-health/the_tuva_project>
+- Tuva Connector Template: <https://github.com/tuva-health/connector_template>
+- CMS Code Sets: <https://www.cms.gov/medicare/coding-billing/icd-10-codes>
+
+---
+
+*Research completed: 2026-01-29*
+*Next action: Use findings to inform healthcare-analyst agent persona definition*


### PR DESCRIPTION
## Summary

- Add healthcare-analyst agent (`hc:`) as a domain expert consultant for healthcare data projects
- Provides terminology guidance, clinical data validation, and data enrichment strategies
- Advisory role only (no code writing) - hands off to dbt-developer, data-modeler, etc.
- Update AGENTS.md to include healthcare-analyst in selection guide and assembly line
- Update ROADMAP.md to assign healthcare-analyst to Epics E7, E8, E10, E11

## Key Features

- Complete healthcare terminology reference (ICD-10, SNOMED, CPT, LOINC, RxNorm, HCPCS, NDC)
- Clinical vs claims data patterns from Tuva Project research
- Data enrichment strategies (crosswalks, value sets, external sources)
- HIPAA/PHI compliance guidance
- Healthcare-specific red flags and quality checklist

## Research Sources

Based on analysis of:
- `tuva-health/the_tuva_project` - Healthcare dbt patterns, terminology handling
- `affaan-m/everything-claude-code` - Claude Code agent structure patterns
- Anthropic agent specialization best practices

## Files Changed

| File | Change |
|------|--------|
| `.claude/agents/healthcare-analyst.md` | **NEW** - Full persona definition |
| `.claude/agents/AGENTS.md` | Add to selection guide and assembly line |
| `docs/plans/ROADMAP.md` | Add to agent assignments |
| `docs/research/HEALTHCARE-AGENT-SYNTHESIS-2026-01-29.md` | **NEW** - Research synthesis |
| `docs/research/REPO-RESEARCH-the_tuva_project-2026-01-29.md` | **NEW** - Tuva research |

## Test plan

- [x] Verify healthcare-analyst.md has valid YAML frontmatter
- [x] Verify AGENTS.md references healthcare-analyst correctly
- [x] Verify ROADMAP.md assigns healthcare-analyst to appropriate epics
- [ ] Test agent invocation: `hc: What ICD-10 codes indicate diabetes?`

🤖 Generated with [Claude Code](https://claude.ai/code)