### PR TITLE
docs(workflow): add git worktree support for parallel sessions

### DIFF
--- a/.claude/agents/AGENTS.md
+++ b/.claude/agents/AGENTS.md
@@ -772,6 +772,17 @@ active_track: feat/customer-analytics
     └─────────────┘  └─────────────┘  └─────────────┘
 ```
 
+**Multi-Worktree Support**:
+
+Supervisor can manage multiple parallel work tracks across git worktrees:
+
+- Each worktree = isolated Claude Code session
+- Supervisor tracks all active worktrees via `git worktree list`
+- Routes tasks to appropriate worktree/session
+- `super: status` shows all active tracks including worktree locations
+
+See [[docs/for_chris/GIT-WORKTREE-WORKFLOW.md]] for worktree workflow details.
+
 **See**: [[supervisor.md]] for full persona details, [[../commands/supervisor.md]] for command usage.
 
 ### dbt Development Agents

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -64,6 +64,55 @@ git push origin main
 - Force push to main/master
 - `gh pr merge` without review
 
+## Git Worktrees (Parallel Sessions)
+
+Git worktrees enable multiple Claude Code sessions to work simultaneously on different features without conflicts.
+
+### Worktree Creation
+
+All worktree operations go through git-master:
+
+```bash
+git: create worktree for feat/customer-analytics
+```
+
+Git-master will:
+
+1. Create branch from main
+2. Create worktree directory as sibling (`../dbt-playground--customer-analytics`)
+3. Push branch to origin
+4. Create draft PR for visibility
+
+### Worktree Rules
+
+| Rule | Enforcement |
+|------|-------------|
+| One branch per worktree | Git enforces (cannot checkout same branch in two places) |
+| Push after each commit | Other worktrees see changes via `git fetch` |
+| Clean up after merge | `git worktree remove`, then delete branch |
+
+### Directory Convention
+
+Worktrees are siblings to the main repo:
+
+```text
+~/projects/
+├── dbt-playground/                    # Main repo
+├── dbt-playground--customer-analytics/ # Worktree
+└── dbt-playground--tuva/               # Worktree
+```
+
+### Draft PR Workflow
+
+```bash
+# At worktree creation, create draft PR immediately
+cd ../dbt-playground--feat-x
+git push -u origin feat/x
+gh pr create --draft --title "feat: description" --body "WIP scope"
+```
+
+This ensures all parallel work is visible in GitHub.
+
 ## Versioning
 
 `vMAJOR.MINOR.PATCH` (Semantic Versioning)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,52 @@ See `.claude/agents/AGENTS.md` for orchestration details.
 | `/plan` | Structured planning |
 | `/dbt-run` | Execute dbt commands |
 
+## Git Worktrees (Parallel Development)
+
+This project supports parallel Claude Code sessions using git worktrees. Each worktree provides an isolated directory with its own branch.
+
+### Detecting Worktree Context
+
+Check if you are in a worktree or the main repo:
+
+```bash
+git worktree list  # Shows all worktrees
+pwd                # Current directory
+git branch --show-current  # Current branch
+```
+
+**Directory naming**: `dbt-playground--{branch-slug}` (e.g., `dbt-playground--tuva`)
+
+### Worktree Workflow Rules
+
+| Rule | Rationale |
+|------|-----------|
+| One branch per worktree | Git enforces this to prevent conflicts |
+| Commit early and often | Per-model or per-feature granularity |
+| Push after each commit | So other worktrees see changes via `git fetch` |
+| Draft PRs at worktree creation | Track work-in-progress in GitHub |
+
+### State Tracking
+
+- **WORKFLOW_STATE.md** lives in the **main repo** (`temp/WORKFLOW_STATE.md`)
+- PR description is the source of truth for feature scope
+- Each worktree may have local state but it is not committed
+
+### Key Commands
+
+```bash
+# Create worktree with new branch
+git worktree add ../dbt-playground--feat-x -b feat/x main
+
+# List all worktrees
+git worktree list
+
+# Remove worktree after merge
+git worktree remove ../dbt-playground--feat-x
+```
+
+**Full guide**: See `docs/for_chris/GIT-WORKTREE-WORKFLOW.md`
+
 ## Notes for Claude
 
 - ASK rather than assume

--- a/docs/for_chris/GIT-WORKTREE-WORKFLOW.md
+++ b/docs/for_chris/GIT-WORKTREE-WORKFLOW.md
@@ -1,0 +1,529 @@
+---
+audience: [human, sage]
+priority: high
+size: medium
+last_updated: 2026-01-29
+status: active
+tags: [learning, git, workflow, parallel-development, multi-session]
+---
+
+# Git Worktrees: Parallel Development for Multi-Session Workflows
+
+**Topic**: Using git worktrees to run multiple Claude Code sessions in parallel, each working on different features without conflicts
+
+**Context**: When you have 3+ Claude Code terminals open, each as a "team" working on separate features, git worktrees provide isolation while sharing the same repository
+
+**Why this matters**: Without worktrees, multiple sessions fight over the same working directory. With worktrees, each session has its own sandbox while sharing commits instantly.
+
+---
+
+## The Problem: One Directory, Many Sessions
+
+Imagine this scenario:
+
+- Terminal 1: Claude is building customer analytics (on `feat/customer-analytics`)
+- Terminal 2: Claude is fixing a production bug (on `fix/null-handling`)
+- Terminal 3: Claude is writing documentation (on `docs/api-reference`)
+
+Without worktrees, they're all operating on the same directory. When Terminal 2 switches to `fix/null-handling`, it overwrites the uncommitted changes from Terminal 1's work on customer analytics.
+
+You end up with:
+
+- Constant stashing and unstashing
+- "Wait, whose changes are these?"
+- Lost work when branches switch
+- Agents stepping on each other's files
+
+**Worktrees solve this by giving each branch its own directory.**
+
+---
+
+## The Mental Model: Same Brain, Different Hands
+
+Think of your git repository as a brain (the `.git` directory), and worktrees as hands:
+
+```
+                 ┌─────────────────────────────────────┐
+                 │          .git (the brain)           │
+                 │   commits, branches, history        │
+                 └──────────────┬──────────────────────┘
+                                │
+         ┌──────────────────────┼──────────────────────┐
+         │                      │                      │
+         ▼                      ▼                      ▼
+┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐
+│   Main Repo     │  │   Worktree 1    │  │   Worktree 2    │
+│   (main)        │  │ (feat/customer) │  │ (fix/null)      │
+│                 │  │                 │  │                 │
+│  dbt-playground │  │ ../wt-customer  │  │ ../wt-null-fix  │
+└─────────────────┘  └─────────────────┘  └─────────────────┘
+```
+
+All three directories:
+
+- Share the same commit history
+- See each other's pushed commits instantly
+- Can independently stage, commit, and push
+- Have their own working files
+
+**Key insight**: When you commit in one worktree and push, other worktrees can see it with `git fetch`. No merging needed - they share the same repository.
+
+---
+
+## Core Concepts
+
+### What Is a Worktree?
+
+A worktree is a checked-out branch in a separate directory. Each worktree:
+
+- Has its own working directory (files you edit)
+- Has its own index (staging area)
+- Shares the `.git` database with the main repo
+- Is locked to one branch (can't checkout the same branch twice)
+
+### Main Repo vs. Worktree Directories
+
+```
+# Main repository (original clone)
+~/projects/dbt-playground/
+├── .git/                    # The shared brain
+├── dbt_project/             # Working files for main
+├── docs/
+└── ...
+
+# Worktree for customer analytics
+~/projects/wt-customer-analytics/
+├── .git                     # File pointing to main .git
+├── dbt_project/             # Working files for this branch
+├── docs/
+└── ...
+```
+
+The worktree's `.git` is a file (not a directory) that points to the main `.git`:
+
+```bash
+$ cat ~/projects/wt-customer-analytics/.git
+gitdir: /Users/chris/projects/dbt-playground/.git/worktrees/wt-customer-analytics
+```
+
+### Branch Locking: One Branch, One Worktree
+
+Git prevents checking out the same branch in multiple worktrees:
+
+```bash
+# In main repo, on feat/customer-analytics
+$ cd ~/projects/wt-null-fix
+$ git checkout feat/customer-analytics
+fatal: 'feat/customer-analytics' is already checked out at '/Users/chris/projects/dbt-playground'
+```
+
+This is a feature, not a bug. It prevents two sessions from editing the same branch and creating conflicts.
+
+---
+
+## Essential Commands
+
+### Create a Worktree
+
+```bash
+# Create worktree for an existing branch
+git worktree add ../wt-customer-analytics feat/customer-analytics
+
+# Create worktree with a new branch (from current HEAD)
+git worktree add -b feat/new-feature ../wt-new-feature
+
+# Create worktree with new branch from specific base
+git worktree add -b fix/urgent ../wt-urgent main
+```
+
+**Naming convention**: Prefix with `wt-` to easily identify worktree directories.
+
+### List Worktrees
+
+```bash
+$ git worktree list
+/Users/chris/projects/dbt-playground           abc1234 [main]
+/Users/chris/projects/wt-customer-analytics    def5678 [feat/customer-analytics]
+/Users/chris/projects/wt-null-fix              ghi9012 [fix/null-handling]
+```
+
+### Remove a Worktree
+
+```bash
+# Remove after merging (clean removal)
+git worktree remove ../wt-customer-analytics
+
+# Force remove (if uncommitted changes)
+git worktree remove --force ../wt-customer-analytics
+
+# Clean up stale worktree entries (if directory was deleted manually)
+git worktree prune
+```
+
+### Move a Worktree
+
+```bash
+# Rename or relocate
+git worktree move ../wt-old-name ../wt-new-name
+```
+
+---
+
+## Workflow with Claude Code
+
+### Starting a New Track
+
+When you want to start a parallel work stream:
+
+```bash
+# 1. Create branch and worktree together
+cd ~/projects/dbt-playground
+git worktree add -b feat/order-metrics ../wt-order-metrics main
+
+# 2. Create draft PR immediately (so work is tracked)
+cd ../wt-order-metrics
+gh pr create --draft --title "feat: add order metrics" --body "WIP"
+
+# 3. Open new terminal in that directory
+# (or tell Claude which directory to work in)
+```
+
+### Which Terminal Works Where
+
+Assign each terminal a clear purpose:
+
+| Terminal | Directory | Branch | Purpose |
+|----------|-----------|--------|---------|
+| 1 | `dbt-playground` | `main` | Coordination, merges, releases |
+| 2 | `wt-customer-analytics` | `feat/customer-analytics` | Customer analytics feature |
+| 3 | `wt-order-metrics` | `feat/order-metrics` | Order metrics feature |
+| 4 | `wt-hotfix` | `fix/urgent` | Production hotfixes |
+
+### How Claude Knows Where It Is
+
+Claude Code automatically detects its working directory. At the start of each session, verify:
+
+```bash
+# Claude should report this
+pwd
+# → /Users/chris/projects/wt-customer-analytics
+
+git branch --show-current
+# → feat/customer-analytics
+```
+
+**Tip**: Include context at session start:
+
+```
+You are working in the customer-analytics worktree.
+Focus: Building the dim_customers and fct_orders marts.
+Branch: feat/customer-analytics
+```
+
+### Committing and Pushing from Worktrees
+
+Works exactly like normal git:
+
+```bash
+# In worktree directory
+git add .
+git commit -m "feat(marts): add dim_customers model"
+git push origin feat/customer-analytics
+```
+
+Other worktrees see the pushed commits after `git fetch`:
+
+```bash
+# In a different worktree
+git fetch
+git log origin/feat/customer-analytics --oneline -3
+```
+
+### Merging and Cleanup
+
+When a feature is complete:
+
+```bash
+# 1. Merge PR (via GitHub or CLI)
+gh pr merge feat/customer-analytics --squash
+
+# 2. Switch to main repo
+cd ~/projects/dbt-playground
+
+# 3. Update main
+git checkout main
+git pull
+
+# 4. Remove the worktree
+git worktree remove ../wt-customer-analytics
+
+# 5. Delete the branch (if not auto-deleted by merge)
+git branch -d feat/customer-analytics
+```
+
+---
+
+## Common Scenarios
+
+### "I want to start a new feature while v0.4 is in progress"
+
+```bash
+# From main repo
+cd ~/projects/dbt-playground
+
+# Create worktree from main (not from v0.4 branch)
+git worktree add -b feat/new-thing ../wt-new-thing main
+
+# Now you have:
+# - wt-new-thing: clean slate from main
+# - dbt-playground: still on feat/v0.4-work
+```
+
+### "I need to hotfix main while other work continues"
+
+```bash
+# Create hotfix worktree
+git worktree add -b fix/production-bug ../wt-hotfix main
+
+# Work in hotfix terminal
+cd ../wt-hotfix
+# ... fix the bug ...
+git commit -am "fix: resolve null handling in staging"
+git push origin fix/production-bug
+
+# Merge quickly, then cleanup
+gh pr create --title "fix: production null handling" --body "Urgent fix"
+gh pr merge --squash
+git worktree remove ../wt-hotfix
+```
+
+Other worktrees are unaffected and continue their work.
+
+### "Two features need to merge - which goes first?"
+
+Consider dependencies:
+
+1. **Independent features**: Merge in any order
+2. **Feature B depends on Feature A**: Merge A first, then rebase B on main before merging
+
+```bash
+# After merging feature A
+cd ../wt-feature-b
+git fetch
+git rebase origin/main
+# Resolve any conflicts
+git push --force-with-lease
+```
+
+### "I'm done with a track - how to clean up"
+
+Full cleanup checklist:
+
+```bash
+# 1. Ensure all changes committed and pushed
+cd ../wt-feature-x
+git status  # Should be clean
+git push
+
+# 2. Merge the PR
+gh pr merge --squash
+
+# 3. Go to main repo
+cd ~/projects/dbt-playground
+
+# 4. Update main
+git pull origin main
+
+# 5. Remove worktree
+git worktree remove ../wt-feature-x
+
+# 6. Delete remote branch (if not auto-deleted)
+git push origin --delete feat/feature-x
+
+# 7. Prune any stale references
+git worktree prune
+git fetch --prune
+```
+
+---
+
+## Tips for Working with Claude
+
+### Tell Claude Which Worktree at Session Start
+
+Include context in your initial prompt:
+
+```
+Working in: ~/projects/wt-customer-analytics
+Branch: feat/customer-analytics
+Task: Build dim_customers dimension model
+
+The main dbt-playground repo is at ~/projects/dbt-playground.
+```
+
+### Use Supervisor Status to See All Tracks
+
+```
+super: status
+```
+
+This shows all active workflow tracks, which often map to worktrees.
+
+### How Claude Can Detect Worktree Context
+
+Claude Code sees the working directory automatically:
+
+```bash
+# Claude can run this to orient itself
+git worktree list
+pwd
+git branch --show-current
+```
+
+If you switch terminals, remind Claude:
+
+```
+Now working in wt-order-metrics worktree (feat/order-metrics branch).
+```
+
+---
+
+## Gotchas and Pitfalls
+
+### Can't Checkout Same Branch in Two Worktrees
+
+```bash
+# This will fail if feat/x is checked out elsewhere
+git checkout feat/x
+# fatal: 'feat/x' is already checked out at '/path/to/other/worktree'
+```
+
+**Solution**: Each parallel track needs its own branch. Plan branch names ahead.
+
+### Need to Push for Other Worktrees to See Commits
+
+Worktrees share the git database but not uncommitted changes:
+
+```bash
+# Worktree A commits locally
+git commit -m "add feature"
+
+# Worktree B cannot see this until A pushes
+# In Worktree A:
+git push
+
+# In Worktree B:
+git fetch
+git log origin/feat/a --oneline
+```
+
+**Pattern**: Commit early, push often. Especially at natural breakpoints.
+
+### Worktrees and Node Modules / Python Venvs
+
+Each worktree has its own working directory, so dependencies need installing:
+
+```bash
+# In each new worktree
+cd ../wt-new-feature
+uv sync                  # Python dependencies
+npm install              # Node dependencies (if any)
+```
+
+These are separate installs but use the same lockfiles.
+
+### Absolute vs. Relative Paths in Scripts
+
+Scripts should use paths relative to the project root, not absolute paths. This ensures they work in any worktree.
+
+```bash
+# Good: relative to project root
+dbt run --project-dir ./dbt_project
+
+# Bad: hardcoded absolute path
+dbt run --project-dir /Users/chris/projects/dbt-playground/dbt_project
+```
+
+### Don't Delete Worktree Directories Manually
+
+Always use `git worktree remove`:
+
+```bash
+# Wrong
+rm -rf ../wt-old-feature
+
+# Right
+git worktree remove ../wt-old-feature
+```
+
+If you do delete manually, run `git worktree prune` to clean up stale entries.
+
+---
+
+## Directory Layout Recommendation
+
+Keep worktrees as siblings to the main repo:
+
+```
+~/projects/
+├── dbt-playground/              # Main repo (main branch)
+├── wt-customer-analytics/       # Worktree (feat/customer-analytics)
+├── wt-order-metrics/            # Worktree (feat/order-metrics)
+└── wt-hotfix/                   # Worktree (fix/urgent)
+```
+
+Benefits:
+
+- Easy to `cd ../wt-*` between worktrees
+- All project work in one parent directory
+- Clear visual separation
+- `wt-` prefix makes worktrees obvious
+
+---
+
+## Quick Reference Card
+
+```bash
+# Create worktree with new branch
+git worktree add -b feat/name ../wt-name main
+
+# Create worktree for existing branch
+git worktree add ../wt-name existing-branch
+
+# List all worktrees
+git worktree list
+
+# Remove worktree (clean)
+git worktree remove ../wt-name
+
+# Remove worktree (force, uncommitted changes)
+git worktree remove --force ../wt-name
+
+# Clean up stale entries
+git worktree prune
+
+# See which branch each worktree has
+git worktree list --porcelain
+```
+
+---
+
+## Key Takeaways
+
+1. **Worktrees = Parallel Sandboxes**: Same git brain, different working hands
+2. **One Branch Per Worktree**: Git enforces this to prevent conflicts
+3. **Push to Share**: Worktrees share commits through the remote
+4. **Clean Up After Merge**: Remove worktree, prune, delete branch
+5. **Context at Session Start**: Tell Claude which worktree it's in
+
+---
+
+## Related Reading
+
+- [Supervisor Orchestration](./SUPERVISOR_ORCHESTRATION.md) - Multi-track workflow management
+- [Git Workflow Rules](../../.claude/rules/git-workflow.md) - Branch naming and commit conventions
+- [Git Documentation: git-worktree](https://git-scm.com/docs/git-worktree) - Official reference
+
+---
+
+*The best parallel workflows are the ones where each track forgets the others exist - until it's time to merge.*

--- a/docs/for_chris/README.md
+++ b/docs/for_chris/README.md
@@ -33,6 +33,8 @@ Create a FOR_CHRIS doc when ≥2 of these criteria are met:
 
 | Document | Topic | Date |
 |----------|-------|------|
+| [GIT-WORKTREE-WORKFLOW.md](GIT-WORKTREE-WORKFLOW.md) | Parallel development with git worktrees | 2026-01-29 |
+| [SUPERVISOR_ORCHESTRATION.md](SUPERVISOR_ORCHESTRATION.md) | Meta-orchestration and multi-track workflows | 2026-01-29 |
 | [UV_PYTHON_MODERNIZATION.md](UV_PYTHON_MODERNIZATION.md) | Python/uv dependency management for dbt | 2026-01-29 |
 | [PROJECT_ONBOARDING.md](PROJECT_ONBOARDING.md) | Project setup, workflow, roadmap | 2026-01-29 |
 | [KIMBALL_DIMENSIONAL_MODELING.md](KIMBALL_DIMENSIONAL_MODELING.md) | Dimensional modeling principles | 2026-01-28 |

--- a/docs/plans/GITHUB-ISSUES.md
+++ b/docs/plans/GITHUB-ISSUES.md
@@ -568,7 +568,7 @@ Review all staging models for consistency, patterns, and best practices.
 **Milestone**: v0.4.0
 
 **Description**:
-Create the patient dimension with demographics and derived attributes.
+Create the patient dimension with demographics, derived attributes, and SCD Type 2 history tracking.
 
 **Acceptance Criteria**:
 
@@ -576,9 +576,14 @@ Create the patient dimension with demographics and derived attributes.
 - [ ] Natural key preserved (`patient_id`)
 - [ ] All demographic attributes included
 - [ ] Derived fields: `full_name`, `age_years`, `is_deceased`
+- [ ] SCD Type 2 columns: `valid_from`, `valid_to`, `is_current`
+- [ ] Initial load sets valid_from = birth_date, valid_to = NULL, is_current = TRUE
 - [ ] Materialized as table
 - [ ] Tests for unique/not_null on keys
 - [ ] Model compiles and runs successfully
+
+**Technical Notes**:
+SCD Type 2 enables historical analysis. For initial load, all records are current.
 
 ---
 
@@ -597,7 +602,7 @@ Create the provider dimension with specialty information.
 - [ ] Surrogate key generated (`provider_key`)
 - [ ] Natural key preserved (`provider_id`)
 - [ ] Specialty information included
-- [ ] Organization linkage maintained
+- [ ] Organization linkage maintained (`organization_key` FK)
 - [ ] Materialized as table
 - [ ] Tests for unique/not_null on keys
 - [ ] Model compiles and runs successfully
@@ -626,6 +631,33 @@ Create the organizations dimension for healthcare facilities.
 
 ---
 
+### Issue: Create dim_payers dimension
+
+**Epic**: E4-Dimensional-Models
+**Assignee**: dbt-developer
+**Labels**: `enhancement`, `marts`, `dimension`, `priority:high`
+**Milestone**: v0.4.0
+
+**Description**:
+Create the payers dimension for insurance companies with coverage metrics.
+
+**Acceptance Criteria**:
+
+- [ ] Surrogate key generated (`payer_key`)
+- [ ] Natural key preserved (`payer_id`)
+- [ ] All payer attributes included (name, address, phone)
+- [ ] Coverage metrics included (amount_covered, amount_uncovered)
+- [ ] Performance metrics included (covered_encounters, covered_medications, etc.)
+- [ ] Derived `coverage_rate` calculated (amount_covered / total)
+- [ ] Materialized as table
+- [ ] Tests for unique/not_null on keys
+- [ ] Model compiles and runs successfully
+
+**Technical Notes**:
+Full dimension with all Synthea payer attributes. Supports payer analysis use case.
+
+---
+
 ### Issue: Create dim_date dimension
 
 **Epic**: E4-Dimensional-Models
@@ -638,16 +670,16 @@ Create the calendar dimension for time-based analysis.
 
 **Acceptance Criteria**:
 
-- [ ] Date range covers 2015-01-01 to 2025-12-31 (or data range)
+- [ ] Date range covers 1909-01-01 to 2025-12-31 (117 years)
 - [ ] Date key in YYYYMMDD format
 - [ ] Standard calendar attributes (day, week, month, quarter, year)
 - [ ] Weekend flag
-- [ ] US holiday flags (optional)
+- [ ] US holiday flags
 - [ ] Materialized as table
 - [ ] Model compiles and runs successfully
 
 **Technical Notes**:
-Consider using `dbt_date` package for generation.
+Use `dbt_date` package for generation. Date range must cover patient births (earliest 1909) through future buffer (2025).
 
 ---
 
@@ -664,7 +696,7 @@ Create the encounters fact table with all measures and dimension keys.
 **Acceptance Criteria**:
 
 - [ ] Surrogate key generated (`encounter_key`)
-- [ ] All dimension keys present (patient, provider, organization, date)
+- [ ] All dimension keys present (patient, provider, organization, payer, date)
 - [ ] All measures included (costs, duration)
 - [ ] Derived measures calculated (patient_responsibility, duration_minutes)
 - [ ] Denormalized patient context (age at encounter)
@@ -692,6 +724,57 @@ Create unified clinical events fact from conditions, medications, and procedures
 - [ ] Consistent column mapping across sources
 - [ ] Code system preserved (SNOMED, RXNORM)
 - [ ] Materialized as table
+- [ ] Model compiles and runs successfully
+
+---
+
+### Issue: Create fct_encounters_monthly fact table
+
+**Epic**: E4-Dimensional-Models
+**Assignee**: dbt-developer
+**Labels**: `enhancement`, `marts`, `fact`, `aggregate`, `priority:medium`
+**Milestone**: v0.4.0
+
+**Description**:
+Create monthly aggregate of encounters for time-series analysis and dashboard performance.
+
+**Acceptance Criteria**:
+
+- [ ] Grain: One row per year_month x encounter_class
+- [ ] Aggregated encounter count
+- [ ] Unique patient count per period
+- [ ] Cost summaries (total_claim_cost, payer_coverage, patient_responsibility)
+- [ ] Average duration minutes
+- [ ] year_month in YYYY-MM format
+- [ ] Materialized as table
+- [ ] Unique combination test on grain columns
+- [ ] Model compiles and runs successfully
+
+**Technical Notes**:
+Supports US-2 Encounter Trends use case with pre-aggregated monthly data.
+
+---
+
+### Issue: Create fct_encounters_yearly fact table
+
+**Epic**: E4-Dimensional-Models
+**Assignee**: dbt-developer
+**Labels**: `enhancement`, `marts`, `fact`, `aggregate`, `priority:medium`
+**Milestone**: v0.4.0
+
+**Description**:
+Create yearly aggregate of encounters for annual reporting.
+
+**Acceptance Criteria**:
+
+- [ ] Grain: One row per year x encounter_class
+- [ ] Aggregated encounter count
+- [ ] Unique patient count per year
+- [ ] Cost summaries (total_claim_cost, payer_coverage, patient_responsibility)
+- [ ] Average duration minutes
+- [ ] Encounters per patient ratio
+- [ ] Materialized as table
+- [ ] Unique combination test on grain columns
 - [ ] Model compiles and runs successfully
 
 ---
@@ -731,6 +814,7 @@ Create intermediate model with patient condition history.
 - [ ] Total condition count per patient
 - [ ] First diagnosis date
 - [ ] Active conditions list (array or comma-separated)
+- [ ] Chronic condition flags (diabetes, hypertension, heart disease)
 - [ ] Model compiles and runs successfully
 
 ---
@@ -747,11 +831,13 @@ Add referential integrity tests between facts and dimensions.
 
 **Acceptance Criteria**:
 
-- [ ] fct_encounters references valid patient_id in dim_patients
+- [ ] fct_encounters references valid patient_id in dim_patients (where is_current = true)
 - [ ] fct_encounters references valid provider_id in dim_providers
 - [ ] fct_encounters references valid organization_id in dim_organizations
+- [ ] fct_encounters references valid payer_id in dim_payers
 - [ ] fct_encounters references valid date_key in dim_date
 - [ ] fct_clinical_events references valid patient_id
+- [ ] Aggregate facts reference valid date ranges
 - [ ] `dbt test --select marts` passes
 
 ---
@@ -769,6 +855,7 @@ Add comprehensive documentation to all dimensional models.
 **Acceptance Criteria**:
 
 - [ ] `_core__models.yml` created with all models
+- [ ] `_healthcare__models.yml` created for intermediate models
 - [ ] All models have descriptions explaining grain
 - [ ] All columns have descriptions
 - [ ] Example queries added to model descriptions
@@ -792,6 +879,8 @@ Review all dimensional models for patterns and best practices.
 - [ ] Surrogate keys generated deterministically
 - [ ] Naming conventions consistent
 - [ ] No unnecessary denormalization
+- [ ] SCD Type 2 implementation correct
+- [ ] Aggregate fact grains are correct
 - [ ] Query performance acceptable
 - [ ] Document any recommended improvements
 
@@ -923,6 +1012,794 @@ Document how agents should use MCP tools for dbt development.
 
 ---
 
+## Epic 7: Tuva Foundation (E7)
+
+### Issue: Install Tuva Project dbt package
+
+**Epic**: E7-Tuva-Foundation
+**Assignee**: dbt-developer
+**Labels**: `enhancement`, `tuva`, `priority:critical`
+**Milestone**: v0.6.0
+
+**Description**:
+Install the Tuva Project dbt package to enable healthcare analytics.
+
+**Acceptance Criteria**:
+
+- [ ] Add `tuva-health/the_tuva_project` version 0.15.3 to packages.yml
+- [ ] `dbt deps` installs package without conflicts
+- [ ] No version conflicts with existing packages
+- [ ] Document any configuration requirements
+
+---
+
+### Issue: Create stg_synthea__immunizations staging model
+
+**Epic**: E7-Tuva-Foundation
+**Assignee**: dbt-developer
+**Labels**: `enhancement`, `staging`, `tuva`, `priority:high`
+**Milestone**: v0.6.0
+
+**Description**:
+Create immunizations staging model required for Tuva's immunization input table.
+
+**Acceptance Criteria**:
+
+- [ ] Model reads from immunizations CSV
+- [ ] All columns renamed to snake_case
+- [ ] CVX codes preserved
+- [ ] Patient and encounter linkage maintained
+- [ ] `_loaded_at` metadata column added
+- [ ] Model compiles and runs successfully
+
+---
+
+### Issue: Create encounter type mapping seed
+
+**Epic**: E7-Tuva-Foundation
+**Assignee**: data-modeler
+**Labels**: `enhancement`, `tuva`, `seeds`, `priority:high`
+**Milestone**: v0.6.0
+
+**Description**:
+Create seed file mapping Synthea encounter classes to Tuva encounter types.
+
+**Acceptance Criteria**:
+
+- [ ] `encounter_type_mapping.csv` created in seeds/tuva_mappings/
+- [ ] Maps: ambulatory, wellness, urgentcare, emergency, inpatient, outpatient
+- [ ] Tuva types: outpatient, inpatient, emergency, etc.
+- [ ] `dbt seed` loads mapping successfully
+
+---
+
+### Issue: Create LOINC lab codes seed
+
+**Epic**: E7-Tuva-Foundation
+**Assignee**: data-modeler
+**Labels**: `enhancement`, `tuva`, `seeds`, `priority:high`
+**Milestone**: v0.6.0
+
+**Description**:
+Create seed file categorizing LOINC codes as vitals vs laboratory results.
+
+**Acceptance Criteria**:
+
+- [ ] `loinc_lab_codes.csv` created in seeds/tuva_mappings/
+- [ ] Common vital sign LOINC codes categorized
+- [ ] Lab result LOINC codes identified
+- [ ] `dbt seed` loads categorization successfully
+
+---
+
+### Issue: Create int_tuva__patient connector model
+
+**Epic**: E7-Tuva-Foundation
+**Assignee**: dbt-developer
+**Labels**: `enhancement`, `tuva`, `connector`, `priority:critical`
+**Milestone**: v0.6.0
+
+**Description**:
+Create connector model transforming stg_synthea__patients to Tuva patient format.
+
+**Acceptance Criteria**:
+
+- [ ] Gender mapped (M to male, F to female)
+- [ ] Race codes mapped to CDC standards
+- [ ] data_source column added ('synthea')
+- [ ] All required Tuva columns present
+- [ ] Model compiles and runs successfully
+
+---
+
+### Issue: Create int_tuva__encounter connector model
+
+**Epic**: E7-Tuva-Foundation
+**Assignee**: dbt-developer
+**Labels**: `enhancement`, `tuva`, `connector`, `priority:critical`
+**Milestone**: v0.6.0
+
+**Description**:
+Create connector model transforming stg_synthea__encounters to Tuva encounter format.
+
+**Acceptance Criteria**:
+
+- [ ] Encounter class mapped to Tuva types using seed
+- [ ] All required Tuva columns present
+- [ ] data_source column added
+- [ ] Model compiles and runs successfully
+
+---
+
+### Issue: Create remaining clinical connector models
+
+**Epic**: E7-Tuva-Foundation
+**Assignee**: dbt-developer
+**Labels**: `enhancement`, `tuva`, `connector`, `priority:high`
+**Milestone**: v0.6.0
+
+**Description**:
+Create connector models for condition, procedure, medication, observation, lab_result, immunization, practitioner, and location.
+
+**Acceptance Criteria**:
+
+- [ ] int_tuva__condition maps from stg_synthea__conditions
+- [ ] int_tuva__procedure maps from stg_synthea__procedures
+- [ ] int_tuva__medication maps from stg_synthea__medications
+- [ ] int_tuva__observation filters vitals from observations
+- [ ] int_tuva__lab_result filters labs from observations
+- [ ] int_tuva__immunization maps from stg_synthea__immunizations
+- [ ] int_tuva__practitioner maps from stg_synthea__providers
+- [ ] int_tuva__location maps from stg_synthea__organizations
+- [ ] All models compile and run successfully
+
+---
+
+### Issue: Configure Tuva clinical input layer
+
+**Epic**: E7-Tuva-Foundation
+**Assignee**: dbt-developer
+**Labels**: `enhancement`, `tuva`, `config`, `priority:critical`
+**Milestone**: v0.6.0
+
+**Description**:
+Configure dbt_project.yml to enable Tuva's clinical input layer.
+
+**Acceptance Criteria**:
+
+- [ ] clinical_input_enabled: true set in vars
+- [ ] claims_input_enabled: false set in vars
+- [ ] All input table refs point to connector models
+- [ ] `dbt compile --select tuva_health.*` succeeds
+
+---
+
+### Issue: Add tests to Tuva connector models
+
+**Epic**: E7-Tuva-Foundation
+**Assignee**: dbt-tester
+**Labels**: `testing`, `tuva`, `priority:high`
+**Milestone**: v0.6.0
+
+**Description**:
+Add schema tests to all Tuva connector models.
+
+**Acceptance Criteria**:
+
+- [ ] `_tuva_connector__models.yml` created
+- [ ] Primary keys have unique/not_null tests
+- [ ] Foreign keys validated
+- [ ] `dbt test --select tag:tuva_connector` passes
+
+---
+
+### Issue: Document Tuva connector models
+
+**Epic**: E7-Tuva-Foundation
+**Assignee**: dbt-documenter
+**Labels**: `documentation`, `tuva`, `priority:high`
+**Milestone**: v0.6.0
+
+**Description**:
+Document all Tuva connector models with transformation logic.
+
+**Acceptance Criteria**:
+
+- [ ] All connector models have descriptions
+- [ ] Transformation logic documented
+- [ ] Source-to-target mapping documented
+- [ ] `dbt docs generate` includes connector models
+
+---
+
+## Epic 8: Clinical Marts (E8)
+
+### Issue: Enable chronic conditions data mart
+
+**Epic**: E8-Clinical-Marts
+**Assignee**: dbt-developer
+**Labels**: `enhancement`, `tuva`, `marts`, `priority:critical`
+**Milestone**: v0.7.0
+
+**Description**:
+Enable and validate Tuva's chronic conditions data mart.
+
+**Acceptance Criteria**:
+
+- [ ] tuva_chronic_conditions_enabled: true configured
+- [ ] Mart builds successfully
+- [ ] Condition groupings populated for patients with conditions
+- [ ] ~40 condition groups available
+
+---
+
+### Issue: Enable ED classification data mart
+
+**Epic**: E8-Clinical-Marts
+**Assignee**: dbt-developer
+**Labels**: `enhancement`, `tuva`, `marts`, `priority:high`
+**Milestone**: v0.7.0
+
+**Description**:
+Enable and validate Tuva's ED classification data mart.
+
+**Acceptance Criteria**:
+
+- [ ] ed_classification_enabled: true configured
+- [ ] Mart builds successfully
+- [ ] Emergency encounters properly classified
+- [ ] Avoidable ED visits identified
+
+---
+
+### Issue: Enable readmissions data mart
+
+**Epic**: E8-Clinical-Marts
+**Assignee**: dbt-developer
+**Labels**: `enhancement`, `tuva`, `marts`, `priority:high`
+**Milestone**: v0.7.0
+
+**Description**:
+Enable and validate Tuva's readmissions data mart.
+
+**Acceptance Criteria**:
+
+- [ ] readmissions_enabled: true configured
+- [ ] Mart builds successfully
+- [ ] Index admissions identified
+- [ ] 30-day readmission flags calculated
+
+---
+
+### Issue: Enable data profiling mart
+
+**Epic**: E8-Clinical-Marts
+**Assignee**: dbt-developer
+**Labels**: `enhancement`, `tuva`, `quality`, `priority:high`
+**Milestone**: v0.7.0
+
+**Description**:
+Enable Tuva's data profiling for data quality validation.
+
+**Acceptance Criteria**:
+
+- [ ] data_profiling_enabled: true configured
+- [ ] Profiling runs successfully
+- [ ] Quality report generated
+- [ ] Pass rate documented (target: >95%)
+
+---
+
+### Issue: Validate clinical mart outputs
+
+**Epic**: E8-Clinical-Marts
+**Assignee**: dbt-tester
+**Labels**: `testing`, `tuva`, `priority:critical`
+**Milestone**: v0.7.0
+
+**Description**:
+Validate all clinical mart outputs for correctness.
+
+**Acceptance Criteria**:
+
+- [ ] Chronic condition groupings cover all patients with conditions
+- [ ] ED classifications are reasonable for data
+- [ ] Readmission rates within expected ranges
+- [ ] Data quality tests pass (>95%)
+- [ ] Sample analytics queries verified
+
+---
+
+### Issue: Document clinical mart usage
+
+**Epic**: E8-Clinical-Marts
+**Assignee**: dbt-documenter
+**Labels**: `documentation`, `tuva`, `priority:high`
+**Milestone**: v0.7.0
+
+**Description**:
+Document how to use Tuva clinical marts for analytics.
+
+**Acceptance Criteria**:
+
+- [ ] Chronic conditions usage guide
+- [ ] ED classification interpretation
+- [ ] Readmissions analysis examples
+- [ ] Sample SQL queries documented
+
+---
+
+## Epic 9: Claims Acquisition (E9)
+
+### Issue: Research and document CMS SynPUF data
+
+**Epic**: E9-Claims-Acquisition
+**Assignee**: developer
+**Labels**: `research`, `data`, `tuva`, `priority:critical`
+**Milestone**: v0.8.0
+
+**Description**:
+Research CMS SynPUF data structure and document acquisition plan.
+
+**Acceptance Criteria**:
+
+- [ ] CMS SynPUF documentation reviewed
+- [ ] File formats and structures documented
+- [ ] Storage requirements estimated
+- [ ] Download procedure documented
+
+---
+
+### Issue: Download CMS SynPUF data files
+
+**Epic**: E9-Claims-Acquisition
+**Assignee**: developer
+**Labels**: `enhancement`, `data`, `tuva`, `priority:critical`
+**Milestone**: v0.8.0
+
+**Description**:
+Download CMS Synthetic Public Use Files for claims analytics.
+
+**Acceptance Criteria**:
+
+- [ ] Beneficiary summary files downloaded
+- [ ] Inpatient claims files downloaded
+- [ ] Outpatient claims files downloaded
+- [ ] Carrier claims files downloaded
+- [ ] PDE (Part D) files downloaded
+- [ ] Files stored in dbt_project/data/cms_synpuf/
+
+---
+
+### Issue: Create CMS SynPUF source definitions
+
+**Epic**: E9-Claims-Acquisition
+**Assignee**: data-modeler
+**Labels**: `enhancement`, `staging`, `tuva`, `priority:high`
+**Milestone**: v0.8.0
+
+**Description**:
+Create source definitions for all CMS SynPUF tables.
+
+**Acceptance Criteria**:
+
+- [ ] `_cms_synpuf__sources.yml` created
+- [ ] All SynPUF tables defined
+- [ ] Column descriptions added
+- [ ] Basic tests on primary keys
+
+---
+
+### Issue: Verify CMS SynPUF data integrity
+
+**Epic**: E9-Claims-Acquisition
+**Assignee**: dbt-tester
+**Labels**: `testing`, `data`, `tuva`, `priority:high`
+**Milestone**: v0.8.0
+
+**Description**:
+Verify all SynPUF files are readable and have expected structure.
+
+**Acceptance Criteria**:
+
+- [ ] All files readable by DuckDB
+- [ ] Row counts documented
+- [ ] Column counts match CMS documentation
+- [ ] No corrupted files
+
+---
+
+## Epic 10: Claims Connector (E10)
+
+### Issue: Create CMS SynPUF staging models
+
+**Epic**: E10-Claims-Connector
+**Assignee**: dbt-developer
+**Labels**: `enhancement`, `staging`, `tuva`, `priority:critical`
+**Milestone**: v0.9.0
+
+**Description**:
+Create staging models for all CMS SynPUF tables.
+
+**Acceptance Criteria**:
+
+- [ ] stg_synpuf__beneficiary_summary created
+- [ ] stg_synpuf__inpatient_claims created
+- [ ] stg_synpuf__outpatient_claims created
+- [ ] stg_synpuf__carrier_claims created
+- [ ] stg_synpuf__pde created
+- [ ] All models compile and run
+
+---
+
+### Issue: Create int_tuva__eligibility connector
+
+**Epic**: E10-Claims-Connector
+**Assignee**: dbt-developer
+**Labels**: `enhancement`, `tuva`, `connector`, `priority:critical`
+**Milestone**: v0.9.0
+
+**Description**:
+Create connector model transforming beneficiary summary to Tuva eligibility.
+
+**Acceptance Criteria**:
+
+- [ ] Member spans derived from coverage months
+- [ ] Demographics mapped correctly
+- [ ] All required Tuva columns present
+- [ ] Model compiles and runs successfully
+
+---
+
+### Issue: Create int_tuva__medical_claim connector
+
+**Epic**: E10-Claims-Connector
+**Assignee**: dbt-developer
+**Labels**: `enhancement`, `tuva`, `connector`, `priority:critical`
+**Milestone**: v0.9.0
+
+**Description**:
+Create connector model unioning inpatient, outpatient, and carrier claims.
+
+**Acceptance Criteria**:
+
+- [ ] Inpatient claims mapped with claim_type='institutional'
+- [ ] Outpatient claims mapped with claim_type='institutional'
+- [ ] Carrier claims mapped with claim_type='professional'
+- [ ] All required Tuva columns present
+- [ ] Model compiles and runs successfully
+
+---
+
+### Issue: Create int_tuva__pharmacy_claim connector
+
+**Epic**: E10-Claims-Connector
+**Assignee**: dbt-developer
+**Labels**: `enhancement`, `tuva`, `connector`, `priority:critical`
+**Milestone**: v0.9.0
+
+**Description**:
+Create connector model transforming PDE to Tuva pharmacy claims.
+
+**Acceptance Criteria**:
+
+- [ ] NDC codes preserved
+- [ ] Days supply and quantity mapped
+- [ ] Payment amounts mapped
+- [ ] All required Tuva columns present
+- [ ] Model compiles and runs successfully
+
+---
+
+### Issue: Configure Tuva claims input layer
+
+**Epic**: E10-Claims-Connector
+**Assignee**: dbt-developer
+**Labels**: `enhancement`, `tuva`, `config`, `priority:critical`
+**Milestone**: v0.9.0
+
+**Description**:
+Configure dbt_project.yml to enable Tuva's claims input layer.
+
+**Acceptance Criteria**:
+
+- [ ] claims_input_enabled: true set in vars
+- [ ] Eligibility, medical_claim, pharmacy_claim refs configured
+- [ ] `dbt compile --select tuva_health.*` succeeds with claims
+- [ ] Tuva claims validation tests pass
+
+---
+
+### Issue: Test claims connector models
+
+**Epic**: E10-Claims-Connector
+**Assignee**: dbt-tester
+**Labels**: `testing`, `tuva`, `priority:high`
+**Milestone**: v0.9.0
+
+**Description**:
+Add tests and validate claims connector models.
+
+**Acceptance Criteria**:
+
+- [ ] Schema tests on all connector models
+- [ ] Tuva validation tests pass
+- [ ] Referential integrity verified
+- [ ] `dbt test` passes for claims connectors
+
+---
+
+## Epic 11: Financial Marts (E11)
+
+### Issue: Enable Financial PMPM data mart
+
+**Epic**: E11-Financial-Marts
+**Assignee**: dbt-developer
+**Labels**: `enhancement`, `tuva`, `marts`, `priority:critical`
+**Milestone**: v1.0.0
+
+**Description**:
+Enable and validate Tuva's Financial PMPM data mart.
+
+**Acceptance Criteria**:
+
+- [ ] pmpm_enabled: true configured
+- [ ] Mart builds successfully
+- [ ] PMPM by service category calculated
+- [ ] Member months accurate
+
+---
+
+### Issue: Enable CMS-HCC risk adjustment mart
+
+**Epic**: E11-Financial-Marts
+**Assignee**: dbt-developer
+**Labels**: `enhancement`, `tuva`, `marts`, `priority:critical`
+**Milestone**: v1.0.0
+
+**Description**:
+Enable and validate Tuva's CMS-HCC risk adjustment data mart.
+
+**Acceptance Criteria**:
+
+- [ ] cms_hcc_enabled: true configured
+- [ ] Mart builds successfully
+- [ ] HCC conditions assigned
+- [ ] RAF scores calculated
+
+---
+
+### Issue: Enable claims preprocessing
+
+**Epic**: E11-Financial-Marts
+**Assignee**: dbt-developer
+**Labels**: `enhancement`, `tuva`, `marts`, `priority:high`
+**Milestone**: v1.0.0
+
+**Description**:
+Enable Tuva's claims preprocessing for encounter grouping.
+
+**Acceptance Criteria**:
+
+- [ ] claims_preprocessing_enabled: true configured
+- [ ] Claims grouped into encounters
+- [ ] Encounter types assigned
+- [ ] Mart builds successfully
+
+---
+
+### Issue: Validate financial mart outputs
+
+**Epic**: E11-Financial-Marts
+**Assignee**: dbt-tester
+**Labels**: `testing`, `tuva`, `priority:critical`
+**Milestone**: v1.0.0
+
+**Description**:
+Validate all financial mart outputs for correctness.
+
+**Acceptance Criteria**:
+
+- [ ] PMPM values within expected ranges
+- [ ] HCC scores between 0.5 - 5.0 RAF
+- [ ] All financial tests pass
+- [ ] Sample analytics queries verified
+
+---
+
+### Issue: Document financial analytics
+
+**Epic**: E11-Financial-Marts
+**Assignee**: dbt-documenter
+**Labels**: `documentation`, `tuva`, `priority:high`
+**Milestone**: v1.0.0
+
+**Description**:
+Document how to use Tuva financial marts for analytics.
+
+**Acceptance Criteria**:
+
+- [ ] PMPM analysis guide
+- [ ] HCC risk score interpretation
+- [ ] Cost analysis examples
+- [ ] Sample SQL queries documented
+
+---
+
+### Issue: Complete v1.0 milestone
+
+**Epic**: E11-Financial-Marts
+**Assignee**: developer
+**Labels**: `milestone`, `release`, `priority:critical`
+**Milestone**: v1.0.0
+
+**Description**:
+Finalize v1.0 release with complete Tuva integration.
+
+**Acceptance Criteria**:
+
+- [ ] All Tuva clinical marts operational
+- [ ] All Tuva financial marts operational
+- [ ] Documentation complete
+- [ ] CHANGELOG updated
+- [ ] Git tag v1.0.0 created
+- [ ] CLAUDE.md updated to reflect completion
+
+---
+
+## Epic 12: Developer Experience - Git Worktrees (E12)
+
+### Issue: Set up git worktree workflow infrastructure
+
+**Epic**: E12-Developer-Experience
+**Assignee**: developer
+**Labels**: `enhancement`, `workflow`, `priority:critical`
+**Milestone**: v0.4.1
+
+**Description**:
+Establish git worktree conventions and workflow for parallel Claude Code sessions. Each session ("team") can work in isolation without branch conflicts.
+
+**Acceptance Criteria**:
+
+- [ ] Worktree naming convention documented: `dbt-playground-{track}`
+- [ ] Worktree directory location: sibling to main repo (`../dbt-playground-{track}/`)
+- [ ] Branch naming tied to worktree: `feat/{track}-{feature}` or `feat/{track}`
+- [ ] Track names defined (tuva, marts, docs, infra, fix)
+- [ ] Workflow tested with at least 2 concurrent worktrees
+- [ ] No interference between worktrees confirmed
+
+**Technical Notes**:
+
+```bash
+# Create worktree
+git worktree add ../dbt-playground-tuva -b feat/tuva-connectors main
+
+# List worktrees
+git worktree list
+
+# Remove worktree after PR merge
+git worktree remove ../dbt-playground-tuva
+```
+
+---
+
+### Issue: Update CLAUDE.md with worktree guidance
+
+**Epic**: E12-Developer-Experience
+**Assignee**: developer
+**Labels**: `documentation`, `workflow`, `priority:high`
+**Milestone**: v0.4.1
+
+**Description**:
+Add a section to CLAUDE.md explaining how to work with git worktrees for parallel development.
+
+**Acceptance Criteria**:
+
+- [ ] New "Git Worktrees" section in CLAUDE.md
+- [ ] Worktree naming convention documented
+- [ ] Commands for creating worktrees documented
+- [ ] Commands for checking current worktree/branch
+- [ ] Commands for cleanup after PR merge
+- [ ] Guidance on draft PR creation at worktree setup
+- [ ] Note about commit-per-model granularity
+
+**Content to Include**:
+
+```markdown
+## Git Worktrees (Parallel Development)
+
+When running multiple Claude Code sessions, each session should operate in its own git worktree.
+
+### Creating a Worktree
+git worktree add ../dbt-playground-{track} -b feat/{track}-{feature} main
+
+### Check Current Context
+git worktree list
+pwd  # Verify which worktree you're in
+
+### After PR Merge
+git worktree remove ../dbt-playground-{track}
+git branch -d feat/{track}-{feature}
+```
+
+---
+
+### Issue: Create FOR_CHRIS learning doc on worktrees
+
+**Epic**: E12-Developer-Experience
+**Assignee**: sage
+**Labels**: `documentation`, `learning`, `priority:high`
+**Milestone**: v0.4.1
+
+**Description**:
+Create a learning document in docs/for_chris/ explaining git worktrees for parallel development.
+
+**Acceptance Criteria**:
+
+- [ ] `docs/for_chris/GIT_WORKTREES.md` created
+- [ ] Explains what git worktrees are and why they matter
+- [ ] Covers the problem (parallel sessions conflict) and solution
+- [ ] Step-by-step guide for creating worktrees
+- [ ] Visual diagram of worktree structure
+- [ ] Commands reference for common operations
+- [ ] Best practices (max 3-4 concurrent, cleanup after merge)
+- [ ] Troubleshooting section
+
+**Structure**:
+
+```markdown
+# Git Worktrees for Parallel Development
+
+## Why Worktrees?
+- Problem: Multiple Claude sessions share one directory
+- Solution: Each session gets its own worktree
+
+## Quick Reference
+| Action | Command |
+|--------|---------|
+| Create worktree | git worktree add ... |
+| List worktrees | git worktree list |
+| Remove worktree | git worktree remove ... |
+
+## Step-by-Step Guide
+...
+
+## Best Practices
+...
+```
+
+---
+
+### Issue: Update supervisor/orchestrate to be worktree-aware
+
+**Epic**: E12-Developer-Experience
+**Assignee**: developer
+**Labels**: `enhancement`, `agents`, `priority:medium`
+**Milestone**: v0.4.1
+
+**Description**:
+Update the supervisor agent documentation to understand and work with multiple worktrees.
+
+**Acceptance Criteria**:
+
+- [ ] Supervisor persona docs updated with worktree awareness
+- [ ] Can identify which worktree/branch a session is in
+- [ ] Can list active worktrees and their assigned features
+- [ ] Can recommend which worktree to use for a task
+- [ ] Prevents conflicting assignments (same feature in multiple worktrees)
+- [ ] `/orchestrate` command acknowledges worktree context
+
+**Technical Notes**:
+
+```bash
+# Supervisor can use these commands to understand context
+git worktree list
+git branch --show-current
+pwd
+```
+
+---
+
 ## Summary by Milestone
 
 ### v0.2.0 - Foundation (E1 + E2)
@@ -970,16 +1847,30 @@ Document how agents should use MCP tools for dbt development.
 | Create dim_patients dimension | E4 | Critical | dbt-developer |
 | Create dim_providers dimension | E4 | High | dbt-developer |
 | Create dim_organizations dimension | E4 | High | dbt-developer |
+| Create dim_payers dimension | E4 | High | dbt-developer |
 | Create dim_date dimension | E4 | Critical | dbt-developer |
 | Create fct_encounters fact table | E4 | Critical | dbt-developer |
 | Create fct_clinical_events fact table | E4 | High | dbt-developer |
+| Create fct_encounters_monthly fact table | E4 | Medium | dbt-developer |
+| Create fct_encounters_yearly fact table | E4 | Medium | dbt-developer |
 | Create int_encounters__enriched intermediate model | E4 | Medium | dbt-developer |
 | Create int_patients__with_conditions intermediate model | E4 | Medium | dbt-developer |
 | Add referential integrity tests to marts | E4 | High | dbt-tester |
 | Document dimensional models | E4 | High | dbt-documenter |
 | Code review dimensional models | E4 | High | code-reviewer |
 
-**Total Issues**: 11
+**Total Issues**: 14
+
+### v0.4.1 - Developer Experience (E12)
+
+| Issue | Epic | Priority | Assignee |
+|-------|------|----------|----------|
+| Set up git worktree workflow infrastructure | E12 | Critical | developer |
+| Update CLAUDE.md with worktree guidance | E12 | High | developer |
+| Create FOR_CHRIS learning doc on worktrees | E12 | High | sage |
+| Update supervisor/orchestrate to be worktree-aware | E12 | Medium | developer |
+
+**Total Issues**: 4
 
 ### v0.5.0 - Production Quality (E5 + E6)
 
@@ -991,6 +1882,83 @@ Document how agents should use MCP tools for dbt development.
 | Test MCP discovery tools | E6 | High | developer |
 | Test MCP SQL execution tools | E6 | High | dbt-developer |
 | Document agent workflow with MCP | E6 | Medium | sage |
+
+**Total Issues**: 6
+
+---
+
+### v0.6.0 - Tuva Foundation (E7)
+
+| Issue | Epic | Priority | Assignee |
+|-------|------|----------|----------|
+| Install Tuva Project dbt package | E7 | Critical | dbt-developer |
+| Create stg_synthea__immunizations staging model | E7 | High | dbt-developer |
+| Create encounter type mapping seed | E7 | High | data-modeler |
+| Create LOINC lab codes seed | E7 | High | data-modeler |
+| Create int_tuva__patient connector model | E7 | Critical | dbt-developer |
+| Create int_tuva__encounter connector model | E7 | Critical | dbt-developer |
+| Create remaining clinical connector models | E7 | High | dbt-developer |
+| Configure Tuva clinical input layer | E7 | Critical | dbt-developer |
+| Add tests to Tuva connector models | E7 | High | dbt-tester |
+| Document Tuva connector models | E7 | High | dbt-documenter |
+
+**Total Issues**: 10
+
+---
+
+### v0.7.0 - Clinical Analytics (E8)
+
+| Issue | Epic | Priority | Assignee |
+|-------|------|----------|----------|
+| Enable chronic conditions data mart | E8 | Critical | dbt-developer |
+| Enable ED classification data mart | E8 | High | dbt-developer |
+| Enable readmissions data mart | E8 | High | dbt-developer |
+| Enable data profiling mart | E8 | High | dbt-developer |
+| Validate clinical mart outputs | E8 | Critical | dbt-tester |
+| Document clinical mart usage | E8 | High | dbt-documenter |
+
+**Total Issues**: 6
+
+---
+
+### v0.8.0 - Claims Ready (E9)
+
+| Issue | Epic | Priority | Assignee |
+|-------|------|----------|----------|
+| Research and document CMS SynPUF data | E9 | Critical | developer |
+| Download CMS SynPUF data files | E9 | Critical | developer |
+| Create CMS SynPUF source definitions | E9 | High | data-modeler |
+| Verify CMS SynPUF data integrity | E9 | High | dbt-tester |
+
+**Total Issues**: 4
+
+---
+
+### v0.9.0 - Claims Connector (E10)
+
+| Issue | Epic | Priority | Assignee |
+|-------|------|----------|----------|
+| Create CMS SynPUF staging models | E10 | Critical | dbt-developer |
+| Create int_tuva__eligibility connector | E10 | Critical | dbt-developer |
+| Create int_tuva__medical_claim connector | E10 | Critical | dbt-developer |
+| Create int_tuva__pharmacy_claim connector | E10 | Critical | dbt-developer |
+| Configure Tuva claims input layer | E10 | Critical | dbt-developer |
+| Test claims connector models | E10 | High | dbt-tester |
+
+**Total Issues**: 6
+
+---
+
+### v1.0.0 - Full Analytics Platform (E11)
+
+| Issue | Epic | Priority | Assignee |
+|-------|------|----------|----------|
+| Enable Financial PMPM data mart | E11 | Critical | dbt-developer |
+| Enable CMS-HCC risk adjustment mart | E11 | Critical | dbt-developer |
+| Enable claims preprocessing | E11 | High | dbt-developer |
+| Validate financial mart outputs | E11 | Critical | dbt-tester |
+| Document financial analytics | E11 | High | dbt-documenter |
+| Complete v1.0 milestone | E11 | Critical | developer |
 
 **Total Issues**: 6
 
@@ -1011,9 +1979,20 @@ Document how agents should use MCP tools for dbt development.
 | `intermediate` | Intermediate models |
 | `dimension` | Dimension tables |
 | `fact` | Fact tables |
+| `aggregate` | Aggregate fact tables |
 | `data` | Data-related work |
 | `mcp` | MCP integration |
 | `quality` | Data quality |
+| `tuva` | Tuva Project integration |
+| `connector` | Tuva connector models |
+| `seeds` | Seed file work |
+| `config` | Configuration changes |
+| `research` | Research/discovery work |
+| `milestone` | Milestone completion |
+| `release` | Release-related work |
+| `workflow` | Developer workflow improvements |
+| `agents` | Agent system updates |
+| `learning` | Learning documentation |
 | `priority:critical` | Must have for milestone |
 | `priority:high` | Should have for milestone |
 | `priority:medium` | Nice to have |
@@ -1047,4 +2026,5 @@ Or use the GitHub web interface to create issues manually.
 ---
 
 *Document Created: 2026-01-28*
-*Total Issues: 41*
+*Document Updated: 2026-01-29*
+*Total Issues: 80 (44 original + 32 Tuva integration + 4 Developer Experience)*

--- a/docs/reference/PROJECT_STRUCTURE.md
+++ b/docs/reference/PROJECT_STRUCTURE.md
@@ -12,6 +12,8 @@ tags: [reference, structure, organization]
 
 ## Directory Overview
 
+**Note**: When using git worktrees for parallel development, worktree directories are siblings to the main repo (e.g., `../dbt-playground--feat-x/`). See [Git Worktree Workflow](../for_chris/GIT-WORKTREE-WORKFLOW.md).
+
 ```text
 dbt-playground/
 ├── CLAUDE.md                  # Project context for Claude (auto-loaded)

--- a/docs/specs/PRD-013-GIT-WORKTREE-WORKFLOW.md
+++ b/docs/specs/PRD-013-GIT-WORKTREE-WORKFLOW.md
@@ -1,0 +1,379 @@
+---
+title: Git Worktree Workflow
+prd_number: PRD-013
+epic: E12-Developer-Experience
+version: 1.0.0
+status: draft
+author: pm
+created: 2026-01-29
+last_updated: 2026-01-29
+---
+
+## Overview
+
+### Problem Statement
+
+When running multiple Claude Code sessions (3+ terminals) simultaneously, each working on different features, all sessions share the same working directory. This creates conflicts:
+
+1. **Branch conflicts**: One session switches branches while another is mid-work
+2. **Uncommitted changes**: Session A's changes block Session B's branch switch
+3. **State confusion**: Claude cannot reliably know which branch/feature it is working on
+4. **Lost context**: Switching branches loses in-progress work from other sessions
+
+This makes parallel "team" development inefficient and error-prone.
+
+### Goal
+
+Enable parallel development workflows where each Claude Code session operates in an isolated git worktree with its own branch, directory, and tracked state. Sessions can work independently without interfering with each other.
+
+### Success Metrics
+
+- 3+ Claude sessions can work simultaneously without branch/file conflicts
+- Each session maintains awareness of its assigned worktree and feature
+- Draft PRs created at worktree creation for visibility
+- Clear workflow for creating, using, and cleaning up worktrees
+- Documentation enables Chris to understand and manage worktrees
+
+---
+
+## User Stories
+
+### US-1: Independent Session Work
+
+**As a** user running multiple Claude Code sessions
+**I want** each session to work in its own isolated directory
+**So that** I can have parallel teams working on different features without conflicts
+
+**Acceptance Criteria**:
+
+- [ ] Each worktree has its own directory (e.g., `../dbt-playground-tuva/`)
+- [ ] Each worktree is tied to a specific feature branch
+- [ ] Sessions can build/test without affecting other sessions
+- [ ] Switching focus between sessions does not lose work
+
+### US-2: Session State Awareness
+
+**As** Claude working in a session
+**I want** to know which worktree/branch I am in and what task I am working on
+**So that** I can maintain context and make appropriate commits
+
+**Acceptance Criteria**:
+
+- [ ] Worktree state is discoverable (via git worktree list or state file)
+- [ ] Current branch and feature scope are clear
+- [ ] Progress tracking per worktree (WORKFLOW_STATE.md or similar)
+- [ ] Claude can report which "team" it is operating as
+
+### US-3: Visibility Through Draft PRs
+
+**As a** user managing multiple parallel features
+**I want** a draft PR created when a worktree/branch is created
+**So that** I can see all in-progress work in GitHub and track progress
+
+**Acceptance Criteria**:
+
+- [ ] Draft PR created with feature description at worktree setup
+- [ ] PR title includes feature/worktree identifier
+- [ ] PR body includes scope and acceptance criteria
+- [ ] Commits push to branch and appear in PR
+
+### US-4: Learning and Management
+
+**As** Chris (the user)
+**I want** to understand how worktrees work and how to manage them
+**So that** I can set up, monitor, and clean up parallel development
+
+**Acceptance Criteria**:
+
+- [ ] FOR_CHRIS learning doc explains worktree concepts
+- [ ] Commands for creating/listing/removing worktrees documented
+- [ ] Best practices for worktree naming and branch management
+- [ ] Cleanup procedures for completed features
+
+---
+
+## Requirements
+
+### Functional Requirements
+
+#### FR-1: Worktree Naming Convention
+
+**Priority**: P0 (Critical)
+
+Worktrees must follow a consistent naming pattern for discoverability.
+
+**Specification**:
+
+| Component | Pattern | Example |
+|-----------|---------|---------|
+| Directory | `dbt-playground-{track}` | `dbt-playground-tuva` |
+| Location | Sibling to main repo | `../dbt-playground-tuva/` |
+| Branch | `feat/{track}-{feature}` or `feat/{track}` | `feat/tuva-connectors` |
+
+**Track Names** (suggested):
+
+- `tuva` - Tuva integration work
+- `marts` - Dimensional models / marts
+- `docs` - Documentation improvements
+- `infra` - Infrastructure / tooling
+- `fix` - Bug fixes
+
+#### FR-2: Branch Naming Tied to Worktree
+
+**Priority**: P0 (Critical)
+
+Each worktree must have a dedicated branch that is not used elsewhere.
+
+**Rules**:
+
+- One branch per worktree (enforced by git)
+- Branch created at worktree creation time
+- Branch name includes track identifier
+- Branch pushed to origin for PR creation
+
+#### FR-3: Draft PR at Worktree Creation
+
+**Priority**: P1 (High)
+
+When creating a worktree, immediately create a draft PR for visibility.
+
+**Workflow**:
+
+```bash
+# 1. Create worktree with new branch
+git worktree add ../dbt-playground-tuva -b feat/tuva-connectors
+
+# 2. Navigate to worktree
+cd ../dbt-playground-tuva
+
+# 3. Push branch and create draft PR
+git push -u origin feat/tuva-connectors
+gh pr create --draft --title "feat(tuva): Tuva connector models" \
+  --body "## Scope\n- [ ] Patient connector\n- [ ] Encounter connector\n..."
+```
+
+#### FR-4: Commit Granularity
+
+**Priority**: P1 (High)
+
+Work in worktrees should follow commit-per-model or commit-per-feature granularity for clean history.
+
+**Guidelines**:
+
+- One commit per model file (for new models)
+- One commit per logical change (for modifications)
+- Meaningful commit messages following conventional commits
+- Regular pushes to keep PR updated
+
+#### FR-5: State Tracking
+
+**Priority**: P2 (Medium)
+
+Each worktree should have a way to track progress and current focus.
+
+**Options**:
+
+| Option | Location | Pros | Cons |
+|--------|----------|------|------|
+| Per-worktree file | `WORKFLOW_STATE.md` in each worktree | Isolated, travels with worktree | Not visible from main |
+| Centralized file | `temp/WORKTREE_STATE.md` in main | Single view of all work | Merge conflicts possible |
+| PR description | GitHub PR body | Visible to all, no file | Requires GitHub access |
+
+**Recommendation**: Use PR description as source of truth with optional local `WORKFLOW_STATE.md` for Claude context.
+
+#### FR-6: Supervisor/Orchestrate Worktree Awareness
+
+**Priority**: P2 (Medium)
+
+The supervisor agent should be aware of worktrees and able to assign work appropriately.
+
+**Capabilities**:
+
+- List active worktrees and their branches
+- Identify which session is which worktree
+- Route tasks to appropriate worktree/session
+- Prevent conflicting assignments
+
+---
+
+### Non-Functional Requirements
+
+#### NFR-1: Minimal Setup Overhead
+
+Creating a worktree should be quick (under 2 minutes including PR creation).
+
+#### NFR-2: No Interference with Main Repo
+
+Worktrees should not affect the main repository state. Work in a worktree should not block work in main or other worktrees.
+
+#### NFR-3: Clean Removal
+
+Worktrees should be easy to clean up after merging:
+
+```bash
+# After PR merge
+git worktree remove ../dbt-playground-tuva
+git branch -d feat/tuva-connectors
+```
+
+---
+
+## Scope
+
+### In Scope
+
+- Worktree workflow definition and naming conventions
+- CLAUDE.md updates with worktree guidance
+- FOR_CHRIS learning documentation
+- Supervisor awareness of worktrees (documentation)
+- Draft PR workflow integration
+
+### Out of Scope
+
+- Automated worktree management scripts (future enhancement)
+- Worktree-aware IDE configuration
+- CI/CD changes for worktree branches
+- Cross-worktree dependency management
+
+---
+
+## Implementation Plan
+
+### Phase 1: Documentation (This PRD)
+
+1. Define worktree conventions (this document)
+2. Create GitHub issues for implementation work
+3. Get approval on workflow
+
+### Phase 2: Documentation Updates
+
+1. Update CLAUDE.md with worktree section
+2. Create FOR_CHRIS learning document
+3. Update git-master agent with worktree commands
+
+### Phase 3: Supervisor Integration
+
+1. Update supervisor persona with worktree awareness
+2. Document orchestration with multiple worktrees
+3. Test parallel session workflow
+
+---
+
+## Workflow Examples
+
+### Example 1: Setting Up a New Feature Track
+
+```bash
+# In main repo directory
+cd /Users/cmbays/Documents/claude/dbt-playground
+
+# Create worktree for Tuva work
+git worktree add ../dbt-playground-tuva -b feat/tuva-connectors main
+
+# Navigate to new worktree
+cd ../dbt-playground-tuva
+
+# Verify setup
+git status  # Shows on feat/tuva-connectors
+
+# Push branch and create draft PR
+git push -u origin feat/tuva-connectors
+gh pr create --draft \
+  --title "feat(tuva): Tuva connector models" \
+  --body "## Overview
+Implement Tuva connector models for clinical data.
+
+## Scope
+- [ ] int_tuva__patient
+- [ ] int_tuva__encounter
+- [ ] int_tuva__condition
+- [ ] Tests and documentation
+
+## Context
+Track: tuva
+Worktree: ../dbt-playground-tuva"
+```
+
+### Example 2: Working in a Worktree Session
+
+```bash
+# Claude starts in worktree
+pwd
+# /Users/cmbays/Documents/claude/dbt-playground-tuva
+
+# Check current state
+git worktree list
+# /Users/cmbays/Documents/claude/dbt-playground       abc1234 [main]
+# /Users/cmbays/Documents/claude/dbt-playground-tuva  def5678 [feat/tuva-connectors]
+
+# Work on feature
+uv run dbt run --select int_tuva__patient
+
+# Commit and push
+git add models/intermediate/tuva/
+git commit -m "feat(tuva): add int_tuva__patient connector"
+git push
+```
+
+### Example 3: Cleaning Up After Merge
+
+```bash
+# After PR is merged to main
+cd /Users/cmbays/Documents/claude/dbt-playground
+
+# Update main
+git checkout main
+git pull
+
+# Remove worktree
+git worktree remove ../dbt-playground-tuva
+
+# Delete local branch (remote deleted via PR merge)
+git branch -d feat/tuva-connectors
+
+# Verify
+git worktree list
+# /Users/cmbays/Documents/claude/dbt-playground  abc1234 [main]
+```
+
+---
+
+## Open Questions
+
+1. **Q**: Should we have a maximum number of concurrent worktrees?
+   **A**: Recommend 3-4 max to keep mental model manageable.
+
+2. **Q**: How does dbt work across worktrees with shared database?
+   **A**: DuckDB file is per-worktree (gitignored), so no conflicts. Each worktree has its own dev.duckdb.
+
+3. **Q**: Should worktree state be committed?
+   **A**: No - worktree state is ephemeral. PR description is the source of truth.
+
+4. **Q**: How do we handle dependencies between worktrees?
+   **A**: Avoid cross-dependencies. If worktree B needs changes from A, merge A first.
+
+---
+
+## Dependencies
+
+### Upstream
+
+- Git worktree support (built into git)
+- GitHub CLI (gh) for PR creation
+
+### Downstream
+
+- All future parallel development work
+- Supervisor orchestration
+
+---
+
+## Related
+
+- **GitHub Issues**: See GITHUB-ISSUES.md Epic 12
+- **Learning Doc**: docs/for_chris/GIT_WORKTREES.md (to be created)
+- **CLAUDE.md**: To be updated with worktree section
+
+---
+
+*PRD Status: Draft - Awaiting Review*


### PR DESCRIPTION
## Summary

Enable multiple Claude Code sessions to work in parallel using git worktrees. Each session gets its own isolated working directory while sharing the git database.

## Problem Solved

- User runs 3+ terminal windows with Claude Code sessions
- All sessions sharing one directory = branch conflicts, file collisions
- Large uncommitted changes accumulate, hard to track progress

## Solution: Git Worktrees

```
~/Documents/claude/
├── dbt-playground/              # Main repo (on main)
├── dbt-playground--feat-v04/    # Worktree: v0.4 work
├── dbt-playground--feat-tuva/   # Worktree: Tuva work
└── dbt-playground--fix-bug/     # Worktree: hotfix
```

## New Artifacts

| File | Purpose |
|------|---------|
| `docs/specs/PRD-013-GIT-WORKTREE-WORKFLOW.md` | Product requirements |
| `docs/for_chris/GIT-WORKTREE-WORKFLOW.md` | Learning guide |

## Updated Docs

- `CLAUDE.md` - Worktree detection and workflow rules
- `.claude/rules/git-workflow.md` - Worktree-specific git rules  
- `.claude/agents/AGENTS.md` - Supervisor multi-worktree support
- `docs/reference/PROJECT_STRUCTURE.md` - Directory layout note
- `docs/plans/GITHUB-ISSUES.md` - Added E12 epic (4 issues)

## Key Workflow Changes

1. **Draft PRs early** - Create at worktree creation for visibility
2. **Commit often** - Per model/feature, not big batch at end
3. **Push after commit** - So other sessions can see progress
4. **Centralized state** - WORKFLOW_STATE.md always in main repo

## Test plan

- [x] Markdown lint passes
- [x] All links valid
- [ ] Manual: Create worktree and verify workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)