### PR TITLE
docs(roadmap): add Tuva integration specs and roadmap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ dbt_project/*.duckdb
 dbt_project/*.duckdb.wal
 dbt_project/data/synthea/*.csv
 logs/
+dev.duckdb

--- a/docs/plans/TUVA-INTEGRATION-PLAN.md
+++ b/docs/plans/TUVA-INTEGRATION-PLAN.md
@@ -1,0 +1,281 @@
+# Tuva Project Integration Plan
+
+**Created**: 2026-01-29
+**Personas**: pm: (product research), arch: (architecture), dbt-model: (data modeling)
+**Status**: APPROVED
+
+---
+
+## Executive Summary
+
+The [Tuva Project](https://github.com/tuva-health/tuva) is an open-source dbt package for healthcare analytics that provides pre-built data marts, terminology sets, and 600+ data quality tests. It's an excellent fit for dbt-playground because:
+
+1. **Synthea Compatibility**: Our 16 Synthea tables map well to Tuva's Clinical Input Layer
+2. **DuckDB Support**: Tuva supports DuckDB (our adapter)
+3. **Learning Value**: Exposes industry-standard healthcare analytics patterns
+4. **Acceleration**: Provides chronic conditions, quality measures, and readmission analytics out-of-the-box
+
+---
+
+## Tuva Project Overview
+
+### What It Provides
+
+| Component | Description |
+|-----------|-------------|
+| **Input Layer** | Standardized API for claims and clinical data |
+| **Core Data Model** | Unified healthcare data structure |
+| **Data Marts** | Pre-built analytics (chronic conditions, quality measures, readmissions) |
+| **Terminology Sets** | ICD-10, SNOMED, LOINC, RxNorm code sets |
+| **Data Quality** | 600+ built-in validation tests |
+
+### Data Marts (Clinical-Compatible)
+
+| Data Mart | Works with Clinical Data? | Value |
+|-----------|---------------------------|-------|
+| **Chronic Conditions** | YES | 40+ condition groupings from diagnosis codes |
+| **ED Classification** | YES | Emergency visit categorization |
+| **Readmissions** | YES | 30-day hospital readmission rates |
+| **Data Quality Intelligence** | YES | 600+ validation tests |
+| **Quality Measures** | PARTIAL | Some HEDIS measures work |
+| Financial PMPM | NO | Requires claims data |
+| CMS-HCCs | NO | Requires claims data |
+
+---
+
+## Synthea to Tuva Mapping
+
+### Table-Level Mapping
+
+| Synthea Table | Tuva Input Table | Mapping Quality | Notes |
+|---------------|------------------|-----------------|-------|
+| `patients` | `patient` | HIGH | Minor gender/race code mapping |
+| `encounters` | `encounter` | HIGH | Encounter class translation needed |
+| `conditions` | `condition` | HIGH | SNOMED codes align |
+| `procedures` | `procedure` | HIGH | SNOMED codes align |
+| `medications` | `medication` | HIGH | RxNorm codes align |
+| `observations` | `observation` | MEDIUM | Split vitals from labs |
+| `observations` | `lab_result` | MEDIUM | Filter by LOINC code type |
+| `immunizations` | `immunization` | HIGH | CVX codes align |
+| `providers` | `practitioner` | HIGH | NPI not in Synthea |
+| `organizations` | `location` | MEDIUM | Granularity difference |
+
+### Tables Without Tuva Mapping
+
+These Synthea tables have no Tuva equivalent (keep in staging for custom analytics):
+
+- `allergies` (598 rows)
+- `careplans` (3,484 rows)
+- `devices` (79 rows)
+- `imaging_studies` (856 rows)
+- `payer_transitions` (3,802 rows)
+- `supplies` (1 row)
+- `payers` (11 rows)
+
+### Key Transformation Requirements
+
+1. **Add `stg_synthea__immunizations`** - Required for Tuva (defer to v0.6)
+2. **Observation/Lab Split** - Filter `observations` by LOINC code to separate vitals from labs
+3. **Encounter Type Mapping** - Synthea (`ambulatory`, `wellness`) to Tuva (`outpatient`, `inpatient`)
+4. **Gender/Race Codes** - Map `M/F` to `male/female`, race codes to CDC standards
+5. **Add `data_source` Column** - Constant 'synthea' for lineage tracking
+
+---
+
+## Recommended Architecture
+
+### Connector Approach
+
+```text
+Synthea Raw Data (16 tables)
+        |
+        v
+Synthea Staging Layer (stg_synthea__*)
+        |
+        v
+Tuva Connector Layer (int_tuva__*)  <-- NEW: Transform to Tuva format
+        |
+        v
+Tuva Input Layer refs
+        |
+        v
+Tuva Data Marts (auto-generated)
+```
+
+### Why This Approach
+
+1. **Preserves Existing Work** - Staging models remain unchanged
+2. **Clean Separation** - Connector layer handles all Tuva-specific transforms
+3. **Reusability** - Staging models still serve custom dimensional models (E4)
+4. **Maintainability** - Tuva updates don't break staging layer
+
+---
+
+## Implementation Plan
+
+### Phase 1: Tuva Foundation (v0.6)
+
+**Scope**: Install Tuva package, build connector layer
+
+```text
+dbt_project/
+├── packages.yml                    # Add tuva-health/the_tuva_project
+├── dbt_project.yml                 # Add clinical_input_enabled: true
+├── seeds/
+│   ├── encounter_type_mapping.csv  # Synthea -> Tuva encounter types
+│   └── loinc_lab_codes.csv         # LOINC codes for lab filtering
+└── models/
+    └── intermediate/
+        └── tuva_connector/
+            ├── _tuva_connector__models.yml
+            ├── int_tuva__patient.sql
+            ├── int_tuva__encounter.sql
+            ├── int_tuva__condition.sql
+            ├── int_tuva__procedure.sql
+            ├── int_tuva__medication.sql
+            ├── int_tuva__observation.sql
+            ├── int_tuva__lab_result.sql
+            ├── int_tuva__immunization.sql
+            ├── int_tuva__practitioner.sql
+            └── int_tuva__location.sql
+```
+
+**packages.yml Addition**:
+
+```yaml
+  - package: tuva-health/the_tuva_project
+    version: 0.15.3
+```
+
+**dbt_project.yml Addition**:
+
+```yaml
+vars:
+  clinical_input_enabled: true
+  claims_input_enabled: false
+
+  # Point Tuva to connector models
+  patient: "{{ ref('int_tuva__patient') }}"
+  encounter: "{{ ref('int_tuva__encounter') }}"
+  condition: "{{ ref('int_tuva__condition') }}"
+  # ... etc
+```
+
+### Phase 2: Clinical Marts (v0.7)
+
+**Scope**: Enable and validate Tuva data marts
+
+```yaml
+vars:
+  tuva_chronic_conditions_enabled: true
+  ed_classification_enabled: true
+  readmissions_enabled: true
+  data_profiling_enabled: true
+```
+
+**Deliverables**:
+
+- Chronic condition groupings for 1,172 patients
+- ED visit classification for emergency encounters
+- 30-day readmission analysis
+- Data quality report with 600+ tests
+
+### Phase 3: Claims Acquisition (v0.8)
+
+**Scope**: Acquire claims data to unlock financial analytics
+
+**Recommended Source**: CMS Synthetic Public Use Files (SynPUF)
+
+- 2 million Medicare beneficiaries
+- Inpatient, outpatient, carrier, and Part D claims
+- Realistic distribution patterns from real Medicare data
+- **Free and public domain**
+
+### Phase 4: Claims Connector (v0.9)
+
+**Scope**: Build connector for claims data
+
+- `eligibility` table from beneficiary summary
+- `medical_claim` from inpatient + outpatient + carrier claims
+- `pharmacy_claim` from prescription drug events
+
+### Phase 5: Financial Marts (v1.0)
+
+**Scope**: Enable financial analytics
+
+- PMPM (Per Member Per Month) cost analysis
+- CMS-HCC risk adjustment scores
+- Drug spend and adherence metrics
+
+---
+
+## Extended Roadmap
+
+| Version | Epic | Focus |
+|---------|------|-------|
+| v0.3 | E3 | Staging (current plan - 9 models) |
+| v0.4 | E4 | Dimensional Models (custom facts/dims) |
+| v0.5 | E5+E6 | Testing & MCP Integration |
+| **v0.6** | **E7** | **Tuva Foundation** (clinical connector) |
+| **v0.7** | **E8** | **Clinical Marts** (chronic conditions, readmissions, ED) |
+| **v0.8** | **E9** | **Claims Acquisition** (CMS SynPUF) |
+| **v0.9** | **E10** | **Claims Connector** (eligibility, medical_claim, pharmacy_claim) |
+| **v1.0** | **E11** | **Financial Marts** (PMPM, cost analysis, HCCs) |
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| dbt version mismatch | Tuva requires 1.9.x+, we have 1.11.2 | Compatible - no action |
+| Terminology mapping gaps | Some SNOMED codes may not map | Use Tuva's terminology seeds |
+| Large observation table | 299K rows may slow builds | Consider incremental materialization |
+| Learning curve | Tuva conventions differ from our patterns | Study Tuva docs, start with one mart |
+| Package conflicts | May conflict with existing packages | Test in isolation branch first |
+
+---
+
+## Verification Plan
+
+### Foundation Verification (v0.6)
+
+```bash
+# Install packages
+dbt deps
+
+# Build connector models
+dbt build --select tag:tuva_connector
+
+# Verify Tuva can read inputs
+dbt compile --select tuva_health.*
+```
+
+### Marts Verification (v0.7)
+
+```bash
+# Build chronic conditions mart
+dbt build --select +chronic_conditions
+
+# Check condition groupings
+dbt show --select chronic_conditions.chronic_conditions --limit 20
+
+# Run data quality
+dbt test --select tuva_health.*
+```
+
+---
+
+## Sources
+
+- [Tuva Project GitHub](https://github.com/tuva-health/tuva)
+- [Tuva Documentation](https://thetuvaproject.com/getting-started/overview)
+- [Tuva Input Layer](https://thetuvaproject.com/input-layer)
+- [Tuva Data Marts](https://thetuvaproject.com/data-marts/overview)
+- [Tuva dbt Hub](https://hub.getdbt.com/tuva-health/the_tuva_project/latest/)
+- [Tuva Connector Template](https://github.com/tuva-health/connector_template)
+- [CMS Synthetic PUF](https://www.cms.gov/data-research/statistics-trends-and-reports/medicare-claims-synthetic-public-use-files)
+
+---
+
+*Approved: 2026-01-29*

--- a/docs/specs/PRD-007-TUVA-FOUNDATION.md
+++ b/docs/specs/PRD-007-TUVA-FOUNDATION.md
@@ -1,0 +1,146 @@
+# PRD-007: Tuva Foundation
+
+## Overview
+
+**Author**: pm: (Product Manager)
+**Status**: Approved
+**Created**: 2026-01-29
+**Updated**: 2026-01-29
+**Epic**: E7
+**Version Target**: v0.6.0
+
+### Problem Statement
+
+The dbt-playground project has 16 Synthea healthcare tables but lacks standardized healthcare analytics capabilities. Building custom analytics from scratch requires significant healthcare domain expertise and development time.
+
+### Goal
+
+Install the Tuva Project dbt package and build a connector layer that transforms Synthea staging models into Tuva's Clinical Input Layer format, enabling pre-built healthcare analytics.
+
+## User Stories
+
+1. As a data engineer, I want to leverage industry-standard healthcare data models so that I can build analytics faster.
+2. As a data analyst, I want access to pre-built healthcare analytics so that I can answer clinical questions without building models from scratch.
+3. As a learner, I want to understand how healthcare data platforms work so that I can apply these patterns in production environments.
+
+## Requirements
+
+### Functional Requirements
+
+1. **FR-1**: Install `tuva-health/the_tuva_project` package version 0.15.3
+2. **FR-2**: Create `stg_synthea__immunizations` staging model (required for Tuva)
+3. **FR-3**: Build 10 connector models transforming staging to Tuva Input Layer
+4. **FR-4**: Create seed files for terminology mappings (encounter types, LOINC codes)
+5. **FR-5**: Configure dbt_project.yml with `clinical_input_enabled: true`
+6. **FR-6**: Document all connector models and transformation logic
+
+### Non-Functional Requirements
+
+1. **NFR-1**: Package installation must not conflict with existing packages
+2. **NFR-2**: Connector models must build in <60 seconds total
+3. **NFR-3**: All models must follow project coding standards
+
+## Acceptance Criteria
+
+- [ ] `dbt deps` installs Tuva package without errors
+- [ ] All 10 connector models compile and run successfully
+- [ ] `dbt compile --select tuva_health.*` succeeds
+- [ ] Schema tests pass for all connector models (unique, not_null on keys)
+- [ ] Documentation exists for all connector models
+
+## Scope
+
+### In Scope
+
+- Tuva package installation and configuration
+- Clinical Input Layer connector models
+- Immunizations staging model
+- Encounter type mapping seed
+- LOINC code categorization seed
+
+### Out of Scope
+
+- Claims Input Layer (no claims data yet - see E9/E10)
+- Tuva data marts (see E8)
+- Custom healthcare analytics beyond Tuva
+
+## Connector Model Specifications
+
+| Model | Source | Key Transformations |
+|-------|--------|---------------------|
+| `int_tuva__patient` | `stg_synthea__patients` | Gender code mapping (M/F to male/female), race code mapping |
+| `int_tuva__encounter` | `stg_synthea__encounters` | Encounter class to type mapping |
+| `int_tuva__condition` | `stg_synthea__conditions` | Add condition_status derivation |
+| `int_tuva__procedure` | `stg_synthea__procedures` | Direct mapping (SNOMED aligned) |
+| `int_tuva__medication` | `stg_synthea__medications` | Direct mapping (RxNorm aligned) |
+| `int_tuva__observation` | `stg_synthea__observations` | Filter vitals by LOINC code |
+| `int_tuva__lab_result` | `stg_synthea__observations` | Filter labs by LOINC code |
+| `int_tuva__immunization` | `stg_synthea__immunizations` | Direct mapping (CVX aligned) |
+| `int_tuva__practitioner` | `stg_synthea__providers` | Add placeholder NPI |
+| `int_tuva__location` | `stg_synthea__organizations` | Map org to location |
+
+## Dependencies
+
+- E5 (Testing & Quality) - Must be complete before starting
+- Tuva Project documentation - Reference for Input Layer schema
+- Synthea staging models - Must exist for all source tables
+
+## Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Package install success | 100% | `dbt deps` completes without errors |
+| Model compile success | 10/10 models | `dbt compile --select tag:tuva_connector` |
+| Test pass rate | 100% | `dbt test --select tag:tuva_connector` |
+| Documentation coverage | 100% | All models have descriptions |
+
+## Technical Design (for arch: TDD)
+
+### File Structure
+
+```text
+dbt_project/
+├── packages.yml                    # Add Tuva package
+├── dbt_project.yml                 # Add clinical_input_enabled variable
+├── seeds/
+│   ├── tuva_mappings/
+│   │   ├── encounter_type_mapping.csv
+│   │   └── loinc_lab_codes.csv
+└── models/
+    ├── staging/synthea/
+    │   └── stg_synthea__immunizations.sql   # NEW
+    └── intermediate/
+        └── tuva_connector/
+            ├── _tuva_connector__models.yml
+            └── int_tuva__*.sql               # 10 models
+```
+
+### Configuration Variables
+
+```yaml
+vars:
+  clinical_input_enabled: true
+  claims_input_enabled: false
+  patient: "{{ ref('int_tuva__patient') }}"
+  encounter: "{{ ref('int_tuva__encounter') }}"
+  condition: "{{ ref('int_tuva__condition') }}"
+  procedure: "{{ ref('int_tuva__procedure') }}"
+  medication: "{{ ref('int_tuva__medication') }}"
+  observation: "{{ ref('int_tuva__observation') }}"
+  lab_result: "{{ ref('int_tuva__lab_result') }}"
+  immunization: "{{ ref('int_tuva__immunization') }}"
+  practitioner: "{{ ref('int_tuva__practitioner') }}"
+  location: "{{ ref('int_tuva__location') }}"
+```
+
+## Open Questions
+
+1. Should we use Tuva's built-in terminology seeds or create custom mappings?
+2. What placeholder value should be used for missing NPI in providers?
+3. Should observation/lab split use a seed file or hardcoded LOINC categories?
+
+## Related
+
+- **TDD**: [TDD-007-TUVA-FOUNDATION.md](./TDD-007-TUVA-FOUNDATION.md)
+- **Issue**: See GITHUB-ISSUES.md
+- **Integration Plan**: [TUVA-INTEGRATION-PLAN.md](../plans/TUVA-INTEGRATION-PLAN.md)

--- a/docs/specs/PRD-008-CLINICAL-MARTS.md
+++ b/docs/specs/PRD-008-CLINICAL-MARTS.md
@@ -1,0 +1,128 @@
+# PRD-008: Clinical Marts
+
+## Overview
+
+**Author**: pm: (Product Manager)
+**Status**: Approved
+**Created**: 2026-01-29
+**Updated**: 2026-01-29
+**Epic**: E8
+**Version Target**: v0.7.0
+
+### Problem Statement
+
+With the Tuva connector layer in place, the project can leverage Tuva's pre-built clinical data marts. These marts provide industry-standard healthcare analytics that would take significant time to build from scratch.
+
+### Goal
+
+Enable and validate Tuva's clinical data marts to provide chronic condition groupings, ED visit classification, readmission analysis, and data quality intelligence for our Synthea patient population.
+
+## User Stories
+
+1. As a data analyst, I want chronic condition groupings so that I can analyze patient cohorts by disease.
+2. As a healthcare analyst, I want ED classification so that I can understand emergency utilization patterns.
+3. As a quality analyst, I want readmission metrics so that I can identify care quality issues.
+4. As a data engineer, I want data quality reports so that I can validate data integrity.
+
+## Requirements
+
+### Functional Requirements
+
+1. **FR-1**: Enable `tuva_chronic_conditions` data mart
+2. **FR-2**: Enable `ed_classification` data mart
+3. **FR-3**: Enable `readmissions` data mart
+4. **FR-4**: Enable `data_profiling` data mart
+5. **FR-5**: Validate analytics outputs for correctness
+6. **FR-6**: Document mart usage and interpretation
+
+### Non-Functional Requirements
+
+1. **NFR-1**: Data marts must build without errors
+2. **NFR-2**: Data quality test pass rate must exceed 95%
+3. **NFR-3**: Chronic condition groupings must cover 100% of patients with conditions
+
+## Acceptance Criteria
+
+- [ ] Chronic conditions mart builds and populates groupings
+- [ ] ED classification correctly categorizes emergency encounters
+- [ ] Readmissions mart calculates 30-day readmission rates
+- [ ] Data profiling generates quality report
+- [ ] All enabled marts pass Tuva's built-in tests
+- [ ] Sample analytics queries documented and verified
+
+## Scope
+
+### In Scope
+
+- Enabling clinical-compatible data marts
+- Validating mart outputs
+- Documenting analytics use cases
+- Creating sample queries
+
+### Out of Scope
+
+- Financial data marts (PMPM, HCCs) - require claims data
+- Custom analytics beyond Tuva marts
+- Dashboard or visualization creation
+
+## Data Mart Specifications
+
+| Mart | Configuration Variable | Key Outputs |
+|------|------------------------|-------------|
+| Chronic Conditions | `tuva_chronic_conditions_enabled: true` | ~40 condition groups per patient |
+| ED Classification | `ed_classification_enabled: true` | ED visit categories (avoidable, etc.) |
+| Readmissions | `readmissions_enabled: true` | 30-day readmission flags, rates |
+| Data Profiling | `data_profiling_enabled: true` | 600+ data quality test results |
+
+## Expected Analytics Outputs
+
+### Chronic Conditions
+
+- Patient-level condition groupings
+- Condition prevalence by population
+- Multi-morbidity analysis capability
+
+### ED Classification
+
+- ED visits categorized by acuity
+- Potentially avoidable ED visits flagged
+- ED utilization patterns
+
+### Readmissions
+
+- Index admissions identified
+- 30-day readmission flags
+- Readmission rates by condition
+
+### Data Quality
+
+- Field-level quality metrics
+- Completeness scores
+- Consistency validation
+
+## Dependencies
+
+- E7 (Tuva Foundation) - Connector layer must be complete
+- Clinical data in Input Layer format
+- Tuva package terminology seeds
+
+## Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Mart build success | 4/4 marts | `dbt build` completes |
+| Patient coverage | 100% | All patients with conditions have groupings |
+| Data quality pass rate | >95% | Data profiling test results |
+| Readmission calculation | Valid | Rates within expected ranges |
+
+## Open Questions
+
+1. What is the expected chronic condition distribution for synthetic data?
+2. Should we create a summary dashboard for mart outputs?
+3. Are there specific quality measures to prioritize?
+
+## Related
+
+- **TDD**: To be created by arch: agent
+- **Issue**: See GITHUB-ISSUES.md
+- **Dependency**: [PRD-007-TUVA-FOUNDATION](./PRD-007-TUVA-FOUNDATION.md)

--- a/docs/specs/PRD-009-CLAIMS-ACQUISITION.md
+++ b/docs/specs/PRD-009-CLAIMS-ACQUISITION.md
@@ -1,0 +1,132 @@
+# PRD-009: Claims Acquisition
+
+## Overview
+
+**Author**: pm: (Product Manager)
+**Status**: Approved
+**Created**: 2026-01-29
+**Updated**: 2026-01-29
+**Epic**: E9
+**Version Target**: v0.8.0
+
+### Problem Statement
+
+Tuva's financial analytics (PMPM, cost analysis, HCC risk scores) require claims data. The current Synthea dataset is clinical-only. To unlock the full potential of the Tuva Project, we need to acquire synthetic claims data.
+
+### Goal
+
+Acquire and load CMS Synthetic Public Use Files (SynPUF) to provide medical claims, pharmacy claims, and eligibility data for financial analytics.
+
+## User Stories
+
+1. As a data engineer, I want claims data so that I can enable Tuva's financial analytics.
+2. As a healthcare analyst, I want realistic Medicare claims so that I can learn claims analytics patterns.
+3. As a learner, I want exposure to claims data structures so that I understand healthcare billing.
+
+## Requirements
+
+### Functional Requirements
+
+1. **FR-1**: Download CMS SynPUF beneficiary summary files
+2. **FR-2**: Download CMS SynPUF inpatient claims files
+3. **FR-3**: Download CMS SynPUF outpatient claims files
+4. **FR-4**: Download CMS SynPUF carrier claims files
+5. **FR-5**: Download CMS SynPUF prescription drug event (PDE) files
+6. **FR-6**: Load all files into DuckDB-accessible location
+7. **FR-7**: Create source definitions for all claims tables
+
+### Non-Functional Requirements
+
+1. **NFR-1**: Data must be public domain (no licensing issues)
+2. **NFR-2**: Storage requirements must be documented
+3. **NFR-3**: Data loading must be reproducible via scripts
+
+## Acceptance Criteria
+
+- [ ] All SynPUF files downloaded and stored in `dbt_project/data/cms_synpuf/`
+- [ ] DuckDB can read all CSV files via `read_csv_auto()`
+- [ ] Source definitions created in `_cms_synpuf__sources.yml`
+- [ ] Row counts verified against CMS documentation
+- [ ] Data dictionary documented
+
+## Scope
+
+### In Scope
+
+- CMS SynPUF Sample 1 (or subset if storage constrained)
+- Beneficiary, inpatient, outpatient, carrier, and PDE files
+- Source definitions and basic validation
+- Download scripts for reproducibility
+
+### Out of Scope
+
+- Full 2M beneficiary dataset (use sample if storage limited)
+- Claims connector models (see E10)
+- Financial analytics (see E11)
+
+## CMS SynPUF File Specifications
+
+| File | Description | Rows (Sample 1) | Target Table |
+|------|-------------|-----------------|--------------|
+| Beneficiary Summary | Demographics, coverage | ~116K | `eligibility` input |
+| Inpatient Claims | Hospital admissions | ~66K | `medical_claim` input |
+| Outpatient Claims | Outpatient services | ~790K | `medical_claim` input |
+| Carrier Claims | Physician services | ~2.8M | `medical_claim` input |
+| PDE (Part D) | Prescription drugs | ~3.1M | `pharmacy_claim` input |
+
+**Source**: [CMS SynPUF](https://www.cms.gov/data-research/statistics-trends-and-reports/medicare-claims-synthetic-public-use-files)
+
+## Data Storage Structure
+
+```text
+dbt_project/data/
+├── synthea/                        # Existing clinical data
+└── cms_synpuf/                     # NEW: Claims data
+    ├── beneficiary_summary_2008.csv
+    ├── beneficiary_summary_2009.csv
+    ├── beneficiary_summary_2010.csv
+    ├── inpatient_claims_2008.csv
+    ├── inpatient_claims_2009.csv
+    ├── outpatient_claims_2008.csv
+    ├── outpatient_claims_2009.csv
+    ├── carrier_claims_2008.csv
+    ├── carrier_claims_2009.csv
+    └── pde_2008.csv
+```
+
+## Dependencies
+
+- E8 (Clinical Marts) - Should be validated before adding complexity
+- Internet access for CMS data download
+- Sufficient disk space (~2-5 GB for sample)
+
+## Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Files downloaded | 100% | All specified files present |
+| DuckDB accessibility | 100% | `read_csv_auto()` succeeds for all |
+| Source definitions | Complete | All tables defined with tests |
+| Data validation | Pass | Row counts match CMS specs |
+
+## Alternative Data Sources
+
+If CMS SynPUF is too large or complex, consider:
+
+| Alternative | Size | Pros | Cons |
+|-------------|------|------|------|
+| Tuva Demo Data | 1K patients | Pre-formatted for Tuva | Small sample |
+| OpenClaims | Varies | Community-maintained | Less realistic |
+| Subset SynPUF | 10-20K beneficiaries | Manageable size | Manual subsetting |
+
+## Open Questions
+
+1. Should we use full SynPUF Sample 1 or create a smaller subset?
+2. How do we handle multi-year beneficiary files?
+3. Should we create a download/setup script for reproducibility?
+
+## Related
+
+- **TDD**: To be created by arch: agent
+- **Issue**: See GITHUB-ISSUES.md
+- **Dependency**: [PRD-008-CLINICAL-MARTS](./PRD-008-CLINICAL-MARTS.md)

--- a/docs/specs/PRD-010-CLAIMS-CONNECTOR.md
+++ b/docs/specs/PRD-010-CLAIMS-CONNECTOR.md
@@ -1,0 +1,155 @@
+# PRD-010: Claims Connector
+
+## Overview
+
+**Author**: pm: (Product Manager)
+**Status**: Approved
+**Created**: 2026-01-29
+**Updated**: 2026-01-29
+**Epic**: E10
+**Version Target**: v0.9.0
+
+### Problem Statement
+
+With CMS SynPUF claims data loaded, we need to transform it into Tuva's Claims Input Layer format. This requires staging models and connector models to map Medicare claims structures to Tuva's standardized schema.
+
+### Goal
+
+Build staging and connector models that transform CMS SynPUF data into Tuva's Claims Input Layer (eligibility, medical_claim, pharmacy_claim), enabling financial analytics.
+
+## User Stories
+
+1. As a data engineer, I want claims in Tuva format so that financial marts can run.
+2. As a healthcare analyst, I want standardized claims data so that I can compare clinical and financial views.
+3. As a learner, I want to understand claims transformation so that I can apply this to real data.
+
+## Requirements
+
+### Functional Requirements
+
+1. **FR-1**: Create staging models for CMS SynPUF tables
+2. **FR-2**: Build `int_tuva__eligibility` connector from beneficiary summary
+3. **FR-3**: Build `int_tuva__medical_claim` connector from inpatient + outpatient + carrier
+4. **FR-4**: Build `int_tuva__pharmacy_claim` connector from PDE
+5. **FR-5**: Configure `claims_input_enabled: true`
+6. **FR-6**: Pass Tuva's claims validation tests
+
+### Non-Functional Requirements
+
+1. **NFR-1**: Connector models must handle millions of rows efficiently
+2. **NFR-2**: Transformations must be documented with business logic
+3. **NFR-3**: All models must follow project coding standards
+
+## Acceptance Criteria
+
+- [ ] All staging models for SynPUF tables compile and run
+- [ ] Eligibility connector produces valid member spans
+- [ ] Medical claim connector unions inpatient + outpatient + carrier
+- [ ] Pharmacy claim connector produces valid prescription records
+- [ ] `dbt compile --select tuva_health.*` succeeds with claims enabled
+- [ ] Tuva claims validation tests pass
+
+## Scope
+
+### In Scope
+
+- Staging models for all SynPUF tables
+- Three claims connector models (eligibility, medical_claim, pharmacy_claim)
+- Configuration for claims input layer
+- Claims-specific schema tests
+
+### Out of Scope
+
+- Financial data marts (see E11)
+- Claims preprocessing configuration
+- Custom claims analytics
+
+## Staging Model Specifications
+
+| Model | Source | Description |
+|-------|--------|-------------|
+| `stg_synpuf__beneficiary_summary` | beneficiary_summary_*.csv | Member demographics, coverage |
+| `stg_synpuf__inpatient_claims` | inpatient_claims_*.csv | Hospital admissions |
+| `stg_synpuf__outpatient_claims` | outpatient_claims_*.csv | Outpatient services |
+| `stg_synpuf__carrier_claims` | carrier_claims_*.csv | Physician services |
+| `stg_synpuf__pde` | pde_*.csv | Part D prescriptions |
+
+## Connector Model Specifications
+
+### int_tuva__eligibility
+
+| Source Column | Target Column | Transformation |
+|---------------|---------------|----------------|
+| DESYNPUF_ID | person_id | Direct mapping |
+| BENE_BIRTH_DT | birth_date | Date conversion |
+| BENE_SEX_IDENT_CD | sex | 1='male', 2='female' |
+| BENE_RACE_CD | race | CMS race code mapping |
+| SP_STATE_CODE | state | State code lookup |
+| BENE_HI_CVRAGE_TOT_MONS | enrollment_start/end | Derive spans |
+
+### int_tuva__medical_claim
+
+| Source | Key Mappings |
+|--------|--------------|
+| Inpatient | claim_type='institutional', ICD diagnosis/procedure codes |
+| Outpatient | claim_type='institutional', ICD diagnosis/procedure codes |
+| Carrier | claim_type='professional', HCPCS codes |
+
+### int_tuva__pharmacy_claim
+
+| Source Column | Target Column | Transformation |
+|---------------|---------------|----------------|
+| DESYNPUF_ID | person_id | Direct mapping |
+| PDE_ID | claim_id | Direct mapping |
+| SRVC_DT | dispensing_date | Date conversion |
+| PROD_SRVC_ID | ndc_code | Direct mapping |
+| QTY_DSPNSD_NUM | quantity | Direct mapping |
+| DAYS_SUPLY_NUM | days_supply | Direct mapping |
+| PTNT_PAY_AMT | paid_amount | Direct mapping |
+
+## File Structure
+
+```text
+dbt_project/models/
+├── staging/
+│   └── cms_synpuf/
+│       ├── _cms_synpuf__sources.yml
+│       ├── _cms_synpuf__models.yml
+│       ├── stg_synpuf__beneficiary_summary.sql
+│       ├── stg_synpuf__inpatient_claims.sql
+│       ├── stg_synpuf__outpatient_claims.sql
+│       ├── stg_synpuf__carrier_claims.sql
+│       └── stg_synpuf__pde.sql
+└── intermediate/
+    └── tuva_connector/
+        ├── int_tuva__eligibility.sql      # NEW
+        ├── int_tuva__medical_claim.sql    # NEW
+        └── int_tuva__pharmacy_claim.sql   # NEW
+```
+
+## Dependencies
+
+- E9 (Claims Acquisition) - SynPUF data must be loaded
+- E7 (Tuva Foundation) - Clinical connector layer must exist
+- Tuva documentation for claims input layer schema
+
+## Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Staging model success | 5/5 models | All compile and run |
+| Connector model success | 3/3 models | All compile and run |
+| Tuva validation | Pass | Claims validation tests |
+| Documentation | 100% | All models documented |
+
+## Open Questions
+
+1. How to handle multi-year beneficiary files (union vs. separate)?
+2. Should carrier claims be split into header/line detail?
+3. What default values for missing fields (e.g., rendering_npi)?
+
+## Related
+
+- **TDD**: To be created by arch: agent
+- **Issue**: See GITHUB-ISSUES.md
+- **Dependency**: [PRD-009-CLAIMS-ACQUISITION](./PRD-009-CLAIMS-ACQUISITION.md)

--- a/docs/specs/PRD-011-FINANCIAL-MARTS.md
+++ b/docs/specs/PRD-011-FINANCIAL-MARTS.md
@@ -1,0 +1,185 @@
+# PRD-011: Financial Marts
+
+## Overview
+
+**Author**: pm: (Product Manager)
+**Status**: Approved
+**Created**: 2026-01-29
+**Updated**: 2026-01-29
+**Epic**: E11
+**Version Target**: v1.0.0
+
+### Problem Statement
+
+With both clinical and claims data flowing through Tuva's Input Layer, we can now enable the full suite of Tuva's financial analytics. This represents the culmination of the Tuva integration, delivering PMPM analysis, HCC risk scores, and comprehensive healthcare analytics.
+
+### Goal
+
+Enable Tuva's financial data marts to provide per-member-per-month cost analysis, CMS-HCC risk adjustment scores, and complete healthcare analytics capabilities, marking the project at v1.0.
+
+## User Stories
+
+1. As a healthcare analyst, I want PMPM metrics so that I can analyze cost by service category.
+2. As a risk analyst, I want HCC scores so that I can understand population risk profiles.
+3. As a data engineer, I want a complete analytics platform so that I can demonstrate full Tuva capabilities.
+4. As a learner, I want financial analytics experience so that I can apply this in production environments.
+
+## Requirements
+
+### Functional Requirements
+
+1. **FR-1**: Enable `financial_pmpm` data mart
+2. **FR-2**: Enable `cms_hcc` (Hierarchical Condition Categories) data mart
+3. **FR-3**: Enable `claims_preprocessing` for encounter grouping
+4. **FR-4**: Validate PMPM calculations for correctness
+5. **FR-5**: Validate HCC risk scores against expected ranges
+6. **FR-6**: Document financial analytics use cases
+
+### Non-Functional Requirements
+
+1. **NFR-1**: Financial calculations must be accurate (verified against sample)
+2. **NFR-2**: All marts must build without errors
+3. **NFR-3**: Documentation must explain metric interpretation
+
+## Acceptance Criteria
+
+- [ ] Financial PMPM mart builds and calculates costs
+- [ ] CMS-HCC mart generates risk adjustment factors
+- [ ] Claims preprocessing groups claims into encounters
+- [ ] PMPM by service category produces valid results
+- [ ] HCC scores fall within expected ranges (0.5 - 5.0 RAF)
+- [ ] Sample analytics queries documented and verified
+- [ ] Project tagged as v1.0.0
+
+## Scope
+
+### In Scope
+
+- Financial PMPM data mart
+- CMS-HCC risk adjustment mart
+- Claims preprocessing mart
+- Financial analytics documentation
+- v1.0 milestone completion
+
+### Out of Scope
+
+- Custom financial reports beyond Tuva
+- Dashboard or visualization creation
+- Integration with external BI tools
+
+## Data Mart Specifications
+
+### Financial PMPM
+
+| Output | Description |
+|--------|-------------|
+| `pmpm_summary` | Overall PMPM by time period |
+| `pmpm_by_service_category` | PMPM by inpatient, outpatient, professional, pharmacy |
+| `pmpm_by_chronic_condition` | PMPM stratified by condition (with member month duplication note) |
+| `member_months` | Monthly enrollment counts |
+
+### CMS-HCC
+
+| Output | Description |
+|--------|-------------|
+| `hcc_conditions` | HCC condition assignments per patient |
+| `risk_scores` | RAF (Risk Adjustment Factor) by patient |
+| `hcc_demographics` | Demographic factors for risk adjustment |
+
+### Claims Preprocessing
+
+| Output | Description |
+|--------|-------------|
+| `encounter` | Claims grouped into clinical encounters |
+| `encounter_type_mapping` | 15 encounter type classifications |
+
+## Configuration Variables
+
+```yaml
+vars:
+  # Previously configured
+  clinical_input_enabled: true
+  claims_input_enabled: true
+
+  # Enable financial marts
+  pmpm_enabled: true
+  cms_hcc_enabled: true
+  claims_preprocessing_enabled: true
+```
+
+## Expected Analytics Outputs
+
+### PMPM Analysis
+
+- Total allowed/paid PMPM
+- PMPM trends over time
+- PMPM by service category
+- High-cost member identification
+
+### HCC Risk Scores
+
+- Population-level RAF distribution
+- Individual patient risk scores
+- HCC condition prevalence
+- Risk-stratified cohorts
+
+### Sample Queries
+
+```sql
+-- Average PMPM by service category
+select
+    service_category,
+    avg(paid_amount_pmpm) as avg_pmpm
+from financial_pmpm.pmpm_by_service_category
+group by 1
+order by 2 desc;
+
+-- HCC risk distribution
+select
+    case
+        when raf < 1.0 then 'Low Risk'
+        when raf < 2.0 then 'Medium Risk'
+        else 'High Risk'
+    end as risk_tier,
+    count(*) as member_count
+from cms_hcc.risk_scores
+group by 1;
+```
+
+## Dependencies
+
+- E10 (Claims Connector) - Claims must be in Tuva format
+- E8 (Clinical Marts) - Clinical marts should be operational
+- Complete Input Layer (clinical + claims)
+
+## Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Mart build success | 3/3 marts | `dbt build` completes |
+| PMPM calculation | Valid | PMPM values within expected ranges |
+| HCC scores | Valid | RAF values between 0.5 - 5.0 |
+| Documentation | Complete | Usage guide and sample queries |
+| Milestone | v1.0.0 | Project tagged and released |
+
+## v1.0 Milestone Checklist
+
+- [ ] All Tuva clinical marts operational
+- [ ] All Tuva financial marts operational
+- [ ] Documentation complete
+- [ ] CHANGELOG updated
+- [ ] Git tag created (v1.0.0)
+- [ ] CLAUDE.md updated to reflect completion
+
+## Open Questions
+
+1. What RAF range is expected for synthetic SynPUF data?
+2. Should we create summary views for common analytics?
+3. Are there specific financial metrics to highlight in documentation?
+
+## Related
+
+- **TDD**: To be created by arch: agent
+- **Issue**: See GITHUB-ISSUES.md
+- **Dependency**: [PRD-010-CLAIMS-CONNECTOR](./PRD-010-CLAIMS-CONNECTOR.md)
+- **Integration Plan**: [TUVA-INTEGRATION-PLAN.md](../plans/TUVA-INTEGRATION-PLAN.md)

--- a/docs/specs/TDD-007-TUVA-FOUNDATION.md
+++ b/docs/specs/TDD-007-TUVA-FOUNDATION.md
@@ -1,0 +1,1154 @@
+# TDD-007: Tuva Foundation Technical Design
+
+## Overview
+
+**Author**: arch: (Architect)
+**Status**: Draft
+**Created**: 2026-01-29
+**PRD Reference**: [PRD-007-TUVA-FOUNDATION](./PRD-007-TUVA-FOUNDATION.md)
+**Epic**: E7
+**Version Target**: v0.6.0
+
+---
+
+## Executive Summary
+
+This TDD provides detailed technical specifications for integrating the Tuva Project healthcare analytics package into dbt-playground. The implementation creates a connector layer that transforms existing Synthea staging models into Tuva's Clinical Input Layer format.
+
+---
+
+## Architecture Overview
+
+### Data Flow
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│                     Raw Data Layer                          │
+│   dbt_project/data/synthea/*.csv (16 tables, 471K rows)     │
+└─────────────────────────┬───────────────────────────────────┘
+                          │
+                          ▼
+┌─────────────────────────────────────────────────────────────┐
+│                    Staging Layer                            │
+│   models/staging/synthea/stg_synthea__*.sql (10 models)     │
+│   - Existing: patients, encounters, conditions, etc.        │
+│   - NEW: stg_synthea__immunizations                         │
+└─────────────────────────┬───────────────────────────────────┘
+                          │
+                          ▼
+┌─────────────────────────────────────────────────────────────┐
+│              Tuva Connector Layer (NEW)                     │
+│   models/intermediate/tuva_connector/int_tuva__*.sql        │
+│   - Transforms staging to Tuva Input Layer schema           │
+│   - 10 connector models                                     │
+└─────────────────────────┬───────────────────────────────────┘
+                          │
+                          ▼
+┌─────────────────────────────────────────────────────────────┐
+│                 Tuva Input Layer                            │
+│   Tuva package reads from connector models via vars         │
+│   clinical_input_enabled: true                              │
+└─────────────────────────┬───────────────────────────────────┘
+                          │
+                          ▼
+┌─────────────────────────────────────────────────────────────┐
+│                Tuva Data Marts (E8)                         │
+│   Chronic Conditions, Readmissions, ED Classification       │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Component Specifications
+
+### 1. Package Installation
+
+**File**: `dbt_project/packages.yml`
+
+```yaml
+packages:
+  # Existing packages
+  - package: dbt-labs/dbt_utils
+    version: 1.3.3
+
+  - package: metaplane/dbt_expectations
+    version: 0.10.10
+
+  - package: godatadriven/dbt_date
+    version: 0.17.1
+
+  - package: dbt-labs/codegen
+    version: 0.14.0
+
+  # NEW: Tuva Project healthcare analytics
+  - package: tuva-health/the_tuva_project
+    version: 0.15.3
+```
+
+**Verification**:
+
+```bash
+cd dbt_project
+dbt deps
+# Expected: Successfully installed 5 packages
+```
+
+---
+
+### 2. Configuration Updates
+
+**File**: `dbt_project/dbt_project.yml`
+
+Add to existing configuration:
+
+```yaml
+name: 'healthcare_analytics'
+version: '0.1.0'
+config-version: 2
+
+profile: 'healthcare_analytics'
+
+# ... existing paths ...
+
+# Model configurations by layer
+models:
+  healthcare_analytics:
+    staging:
+      +materialized: view
+      +schema: staging
+    intermediate:
+      +materialized: view
+      +schema: intermediate
+      # NEW: Tuva connector models
+      tuva_connector:
+        +tags: ['tuva_connector']
+    marts:
+      +materialized: table
+      +schema: marts
+
+# NEW: Tuva configuration variables
+vars:
+  # Enable clinical input layer (EHR/clinical data)
+  clinical_input_enabled: true
+
+  # Disable claims input layer (no claims data yet)
+  claims_input_enabled: false
+
+  # Map Tuva input tables to our connector models
+  input_database: '{{ target.database }}'
+  input_schema: 'intermediate'
+
+  # Clinical input table references
+  patient: "{{ ref('int_tuva__patient') }}"
+  encounter: "{{ ref('int_tuva__encounter') }}"
+  condition: "{{ ref('int_tuva__condition') }}"
+  procedure: "{{ ref('int_tuva__procedure') }}"
+  medication: "{{ ref('int_tuva__medication') }}"
+  observation: "{{ ref('int_tuva__observation') }}"
+  lab_result: "{{ ref('int_tuva__lab_result') }}"
+  immunization: "{{ ref('int_tuva__immunization') }}"
+  practitioner: "{{ ref('int_tuva__practitioner') }}"
+  location: "{{ ref('int_tuva__location') }}"
+
+  # Disable marts for E7 (enable in E8)
+  tuva_chronic_conditions_enabled: false
+  ed_classification_enabled: false
+  readmissions_enabled: false
+  data_profiling_enabled: false
+
+# Seed configurations
+seeds:
+  healthcare_analytics:
+    tuva_mappings:
+      +schema: seeds
+```
+
+---
+
+### 3. Seed File Specifications
+
+#### 3.1 Encounter Type Mapping
+
+**File**: `dbt_project/seeds/tuva_mappings/encounter_type_mapping.csv`
+
+```csv
+synthea_encounter_class,tuva_encounter_type,tuva_encounter_type_description
+ambulatory,outpatient,Outpatient visit
+wellness,outpatient,Wellness/preventive visit
+outpatient,outpatient,Outpatient visit
+urgentcare,emergency,Urgent care visit
+emergency,emergency,Emergency department visit
+inpatient,inpatient,Inpatient hospitalization
+hospice,skilled nursing facility,Hospice care
+home,home health,Home health visit
+snf,skilled nursing facility,Skilled nursing facility
+virtual,telehealth,Virtual/telehealth visit
+```
+
+**Rationale**: Synthea uses encounter classes that need mapping to Tuva's standardized encounter types for proper analytics categorization.
+
+#### 3.2 LOINC Category Mapping
+
+**File**: `dbt_project/seeds/tuva_mappings/loinc_category_mapping.csv`
+
+```csv
+loinc_code,category,description
+8867-4,vital,Heart rate
+8310-5,vital,Body temperature
+8462-4,vital,Diastolic blood pressure
+8480-6,vital,Systolic blood pressure
+9279-1,vital,Respiratory rate
+29463-7,vital,Body weight
+8302-2,vital,Body height
+39156-5,vital,Body mass index
+59408-5,vital,Oxygen saturation
+72166-2,vital,Tobacco smoking status
+2708-6,lab,Oxygen saturation in arterial blood
+2571-8,lab,Triglycerides
+2093-3,lab,Cholesterol total
+2085-9,lab,HDL cholesterol
+2089-1,lab,LDL cholesterol
+4548-4,lab,Hemoglobin A1c
+6299-2,lab,Urea nitrogen
+2160-0,lab,Creatinine
+1751-7,lab,Albumin
+1920-8,lab,AST
+1742-6,lab,ALT
+718-7,lab,Hemoglobin
+26515-7,lab,Platelets
+26464-8,lab,Leukocytes
+```
+
+**Rationale**: Synthea's observations table contains both vital signs and lab results. This mapping enables splitting into separate Tuva input tables.
+
+---
+
+### 4. Staging Model Addition
+
+#### 4.1 stg_synthea__immunizations
+
+**File**: `dbt_project/models/staging/synthea/stg_synthea__immunizations.sql`
+
+```sql
+with source as (
+    select * from {{ source('synthea_raw', 'immunizations') }}
+),
+
+renamed as (
+    select
+        -- foreign keys
+        PATIENT as patient_id
+        , ENCOUNTER as encounter_id
+
+        -- timestamp
+        , cast(DATE as timestamp) as administered_at
+
+        -- immunization details
+        , CODE as cvx_code
+        , DESCRIPTION as vaccine_description
+
+        -- cost
+        , BASE_COST as base_cost
+    from source
+),
+
+with_surrogate_key as (
+    select
+        -- surrogate primary key
+        {{ dbt_utils.generate_surrogate_key(['patient_id', 'encounter_id', 'cvx_code', 'administered_at']) }} as immunization_id
+        , *
+    from renamed
+),
+
+final as (
+    select
+        *
+        , current_timestamp as _loaded_at
+    from with_surrogate_key
+)
+
+select * from final
+```
+
+---
+
+### 5. Connector Model Specifications
+
+All connector models follow this structure:
+
+```text
+models/intermediate/tuva_connector/
+├── _tuva_connector__models.yml    # Documentation and tests
+├── int_tuva__patient.sql
+├── int_tuva__encounter.sql
+├── int_tuva__condition.sql
+├── int_tuva__procedure.sql
+├── int_tuva__medication.sql
+├── int_tuva__observation.sql
+├── int_tuva__lab_result.sql
+├── int_tuva__immunization.sql
+├── int_tuva__practitioner.sql
+└── int_tuva__location.sql
+```
+
+#### 5.1 int_tuva__patient
+
+**Purpose**: Transform patient demographics to Tuva patient schema.
+
+```sql
+{{
+    config(
+        tags=['tuva_connector', 'clinical_input'],
+        materialized='view'
+    )
+}}
+
+with source as (
+    select * from {{ ref('stg_synthea__patients') }}
+),
+
+transformed as (
+    select
+        -- Required fields
+        patient_id as patient_id
+        , patient_id as person_id  -- Tuva uses person_id as primary identifier
+
+        -- Demographics
+        , first_name
+        , last_name
+        , case
+            when gender = 'M' then 'male'
+            when gender = 'F' then 'female'
+            else 'unknown'
+          end as sex
+        , birth_date
+        , death_date
+
+        -- Race mapping (Synthea uses text, Tuva expects standardized codes)
+        , case race
+            when 'white' then 'white'
+            when 'black' then 'black'
+            when 'asian' then 'asian'
+            when 'native' then 'american indian or alaska native'
+            when 'hawaiian' then 'native hawaiian or other pacific islander'
+            when 'other' then 'other'
+            else 'unknown'
+          end as race
+
+        , case ethnicity
+            when 'hispanic' then 'hispanic'
+            when 'nonhispanic' then 'not hispanic'
+            else 'unknown'
+          end as ethnicity
+
+        -- Location
+        , address as address
+        , city
+        , state
+        , zip_code as zip_code
+        , latitude
+        , longitude
+
+        -- Data source tracking
+        , 'synthea' as data_source
+
+    from source
+)
+
+select * from transformed
+```
+
+#### 5.2 int_tuva__encounter
+
+**Purpose**: Transform encounters with type mapping via seed.
+
+```sql
+{{
+    config(
+        tags=['tuva_connector', 'clinical_input'],
+        materialized='view'
+    )
+}}
+
+with source as (
+    select * from {{ ref('stg_synthea__encounters') }}
+),
+
+encounter_mapping as (
+    select * from {{ ref('encounter_type_mapping') }}
+),
+
+transformed as (
+    select
+        -- Keys
+        enc.encounter_id
+        , enc.patient_id as person_id
+        , enc.patient_id
+
+        -- Encounter details
+        , coalesce(map.tuva_encounter_type, 'other') as encounter_type
+        , enc.encounter_class as encounter_class_source
+        , enc.encounter_code
+        , enc.encounter_description
+
+        -- Timestamps
+        , cast(enc.encounter_start_at as date) as encounter_start_date
+        , cast(enc.encounter_end_at as date) as encounter_end_date
+        , enc.encounter_start_at as admit_datetime
+        , enc.encounter_end_at as discharge_datetime
+
+        -- Provider and facility
+        , enc.provider_id as attending_provider_id
+        , enc.organization_id as facility_id
+
+        -- Financials
+        , enc.total_claim_cost as total_cost
+        , enc.payer_coverage as paid_amount
+
+        -- Reason
+        , enc.reason_code as primary_diagnosis_code
+        , enc.reason_description as primary_diagnosis_description
+
+        -- Data source
+        , 'synthea' as data_source
+
+    from source enc
+    left join encounter_mapping map
+        on lower(enc.encounter_class) = lower(map.synthea_encounter_class)
+)
+
+select * from transformed
+```
+
+#### 5.3 int_tuva__condition
+
+**Purpose**: Transform conditions with status derivation.
+
+```sql
+{{
+    config(
+        tags=['tuva_connector', 'clinical_input'],
+        materialized='view'
+    )
+}}
+
+with source as (
+    select * from {{ ref('stg_synthea__conditions') }}
+),
+
+transformed as (
+    select
+        -- Keys
+        condition_id
+        , patient_id as person_id
+        , patient_id
+        , encounter_id
+
+        -- Condition details
+        , condition_code as code
+        , 'snomed-ct' as code_type  -- Synthea uses SNOMED
+        , condition_description as description
+
+        -- Dates
+        , cast(condition_start_date as date) as condition_date
+        , cast(condition_start_date as date) as onset_date
+        , cast(condition_end_date as date) as resolved_date
+
+        -- Derived status
+        , case
+            when condition_end_date is not null then 'resolved'
+            else 'active'
+          end as condition_status
+
+        -- Data source
+        , 'synthea' as data_source
+
+    from source
+)
+
+select * from transformed
+```
+
+#### 5.4 int_tuva__procedure
+
+**Purpose**: Transform procedures (SNOMED codes align directly).
+
+```sql
+{{
+    config(
+        tags=['tuva_connector', 'clinical_input'],
+        materialized='view'
+    )
+}}
+
+with source as (
+    select * from {{ ref('stg_synthea__procedures') }}
+),
+
+transformed as (
+    select
+        -- Keys
+        procedure_id
+        , patient_id as person_id
+        , patient_id
+        , encounter_id
+
+        -- Procedure details
+        , procedure_code as code
+        , 'snomed-ct' as code_type  -- Synthea uses SNOMED
+        , procedure_description as description
+
+        -- Date
+        , cast(procedure_date as date) as procedure_date
+
+        -- Cost
+        , base_cost
+
+        -- Data source
+        , 'synthea' as data_source
+
+    from source
+)
+
+select * from transformed
+```
+
+#### 5.5 int_tuva__medication
+
+**Purpose**: Transform medications (RxNorm codes align directly).
+
+```sql
+{{
+    config(
+        tags=['tuva_connector', 'clinical_input'],
+        materialized='view'
+    )
+}}
+
+with source as (
+    select * from {{ ref('stg_synthea__medications') }}
+),
+
+transformed as (
+    select
+        -- Keys
+        medication_id
+        , patient_id as person_id
+        , patient_id
+        , encounter_id
+
+        -- Medication details
+        , medication_code as code
+        , 'rxnorm' as code_type  -- Synthea uses RxNorm
+        , medication_description as description
+
+        -- Dates
+        , cast(medication_start_at as date) as start_date
+        , cast(medication_stop_at as date) as end_date
+
+        -- Derived status
+        , case
+            when medication_stop_at is not null then 'stopped'
+            else 'active'
+          end as status
+
+        -- Cost
+        , base_cost
+        , total_cost
+
+        -- Data source
+        , 'synthea' as data_source
+
+    from source
+)
+
+select * from transformed
+```
+
+#### 5.6 int_tuva__observation
+
+**Purpose**: Filter observations to vitals only using LOINC mapping.
+
+```sql
+{{
+    config(
+        tags=['tuva_connector', 'clinical_input'],
+        materialized='view'
+    )
+}}
+
+with source as (
+    select * from {{ ref('stg_synthea__observations') }}
+),
+
+loinc_mapping as (
+    select * from {{ ref('loinc_category_mapping') }}
+    where category = 'vital'
+),
+
+-- Filter to vital signs only
+vitals_only as (
+    select obs.*
+    from source obs
+    inner join loinc_mapping loinc
+        on obs.observation_code = loinc.loinc_code
+),
+
+transformed as (
+    select
+        -- Keys
+        observation_id
+        , patient_id as person_id
+        , patient_id
+        , encounter_id
+
+        -- Observation details
+        , observation_code as code
+        , 'loinc' as code_type
+        , observation_description as description
+
+        -- Value
+        , observation_value as value
+        , units as unit
+
+        -- Timestamp
+        , observation_at as observation_datetime
+        , cast(observation_at as date) as observation_date
+
+        -- Data source
+        , 'synthea' as data_source
+
+    from vitals_only
+)
+
+select * from transformed
+```
+
+#### 5.7 int_tuva__lab_result
+
+**Purpose**: Filter observations to lab results only using LOINC mapping.
+
+```sql
+{{
+    config(
+        tags=['tuva_connector', 'clinical_input'],
+        materialized='view'
+    )
+}}
+
+with source as (
+    select * from {{ ref('stg_synthea__observations') }}
+),
+
+loinc_mapping as (
+    select * from {{ ref('loinc_category_mapping') }}
+    where category = 'lab'
+),
+
+-- Filter to lab results only
+labs_only as (
+    select obs.*
+    from source obs
+    inner join loinc_mapping loinc
+        on obs.observation_code = loinc.loinc_code
+),
+
+transformed as (
+    select
+        -- Keys
+        observation_id as lab_result_id
+        , patient_id as person_id
+        , patient_id
+        , encounter_id
+
+        -- Lab details
+        , observation_code as code
+        , 'loinc' as code_type
+        , observation_description as description
+
+        -- Result
+        , observation_value as result_value
+        , units as unit
+
+        -- Timestamp
+        , observation_at as result_datetime
+        , cast(observation_at as date) as result_date
+
+        -- Status (lab results are typically final)
+        , 'final' as status
+
+        -- Data source
+        , 'synthea' as data_source
+
+    from labs_only
+)
+
+select * from transformed
+```
+
+#### 5.8 int_tuva__immunization
+
+**Purpose**: Transform immunizations (CVX codes align directly).
+
+```sql
+{{
+    config(
+        tags=['tuva_connector', 'clinical_input'],
+        materialized='view'
+    )
+}}
+
+with source as (
+    select * from {{ ref('stg_synthea__immunizations') }}
+),
+
+transformed as (
+    select
+        -- Keys
+        immunization_id
+        , patient_id as person_id
+        , patient_id
+        , encounter_id
+
+        -- Immunization details
+        , cvx_code as code
+        , 'cvx' as code_type  -- Synthea uses CVX
+        , vaccine_description as description
+
+        -- Date
+        , cast(administered_at as date) as immunization_date
+        , administered_at as immunization_datetime
+
+        -- Status (administered immunizations are complete)
+        , 'completed' as status
+
+        -- Data source
+        , 'synthea' as data_source
+
+    from source
+)
+
+select * from transformed
+```
+
+#### 5.9 int_tuva__practitioner
+
+**Purpose**: Transform providers to practitioners.
+
+```sql
+{{
+    config(
+        tags=['tuva_connector', 'clinical_input'],
+        materialized='view'
+    )
+}}
+
+with source as (
+    select * from {{ ref('stg_synthea__providers') }}
+),
+
+transformed as (
+    select
+        -- Keys
+        provider_id as practitioner_id
+        , provider_id
+
+        -- Name
+        , provider_name as name
+
+        -- Identifiers
+        -- Note: Synthea doesn't include NPI, using placeholder
+        , null as npi
+
+        -- Specialty
+        , provider_specialty as specialty
+
+        -- Organization link
+        , organization_id as facility_id
+
+        -- Location
+        , provider_address as address
+        , provider_city as city
+        , provider_state as state
+        , provider_zip as zip_code
+
+        -- Data source
+        , 'synthea' as data_source
+
+    from source
+)
+
+select * from transformed
+```
+
+#### 5.10 int_tuva__location
+
+**Purpose**: Transform organizations to locations.
+
+```sql
+{{
+    config(
+        tags=['tuva_connector', 'clinical_input'],
+        materialized='view'
+    )
+}}
+
+with source as (
+    select * from {{ ref('stg_synthea__organizations') }}
+),
+
+transformed as (
+    select
+        -- Keys
+        organization_id as location_id
+        , organization_id as facility_id
+
+        -- Name
+        , organization_name as name
+
+        -- Identifiers
+        -- Note: Synthea doesn't include NPI, using placeholder
+        , null as npi
+
+        -- Location details
+        , organization_address as address
+        , organization_city as city
+        , organization_state as state
+        , organization_zip as zip_code
+        , latitude
+        , longitude
+
+        -- Data source
+        , 'synthea' as data_source
+
+    from source
+)
+
+select * from transformed
+```
+
+---
+
+### 6. YAML Configuration
+
+**File**: `dbt_project/models/intermediate/tuva_connector/_tuva_connector__models.yml`
+
+```yaml
+version: 2
+
+models:
+  - name: int_tuva__patient
+    description: >
+      Transforms Synthea patient demographics to Tuva patient input layer format.
+      Maps gender codes (M/F to male/female) and standardizes race/ethnicity values.
+    columns:
+      - name: patient_id
+        description: Unique patient identifier (from Synthea)
+        data_tests:
+          - unique
+          - not_null
+      - name: person_id
+        description: Tuva person identifier (same as patient_id for single-source)
+        data_tests:
+          - unique
+          - not_null
+      - name: sex
+        description: Standardized sex (male, female, unknown)
+        data_tests:
+          - accepted_values:
+              values: ['male', 'female', 'unknown']
+      - name: data_source
+        description: Source system identifier
+        data_tests:
+          - accepted_values:
+              values: ['synthea']
+
+  - name: int_tuva__encounter
+    description: >
+      Transforms Synthea encounters to Tuva encounter input layer format.
+      Uses encounter_type_mapping seed to translate encounter classes.
+    columns:
+      - name: encounter_id
+        description: Unique encounter identifier
+        data_tests:
+          - unique
+          - not_null
+      - name: person_id
+        description: Patient identifier
+        data_tests:
+          - not_null
+          - relationships:
+              to: ref('int_tuva__patient')
+              field: person_id
+      - name: encounter_type
+        description: Standardized Tuva encounter type
+        data_tests:
+          - not_null
+
+  - name: int_tuva__condition
+    description: >
+      Transforms Synthea conditions to Tuva condition input layer format.
+      Derives condition_status from presence of end date.
+    columns:
+      - name: condition_id
+        description: Unique condition identifier (surrogate key)
+        data_tests:
+          - unique
+          - not_null
+      - name: person_id
+        description: Patient identifier
+        data_tests:
+          - not_null
+      - name: condition_status
+        description: Derived status (active or resolved)
+        data_tests:
+          - accepted_values:
+              values: ['active', 'resolved']
+
+  - name: int_tuva__procedure
+    description: >
+      Transforms Synthea procedures to Tuva procedure input layer format.
+      SNOMED codes pass through directly.
+    columns:
+      - name: procedure_id
+        description: Unique procedure identifier (surrogate key)
+        data_tests:
+          - unique
+          - not_null
+      - name: person_id
+        description: Patient identifier
+        data_tests:
+          - not_null
+
+  - name: int_tuva__medication
+    description: >
+      Transforms Synthea medications to Tuva medication input layer format.
+      RxNorm codes pass through directly.
+    columns:
+      - name: medication_id
+        description: Unique medication identifier (surrogate key)
+        data_tests:
+          - unique
+          - not_null
+      - name: person_id
+        description: Patient identifier
+        data_tests:
+          - not_null
+
+  - name: int_tuva__observation
+    description: >
+      Filters Synthea observations to vital signs only using LOINC mapping.
+      Lab results are routed to int_tuva__lab_result instead.
+    columns:
+      - name: observation_id
+        description: Unique observation identifier (surrogate key)
+        data_tests:
+          - unique
+          - not_null
+      - name: person_id
+        description: Patient identifier
+        data_tests:
+          - not_null
+
+  - name: int_tuva__lab_result
+    description: >
+      Filters Synthea observations to laboratory results only using LOINC mapping.
+      Vital signs are routed to int_tuva__observation instead.
+    columns:
+      - name: lab_result_id
+        description: Unique lab result identifier (surrogate key)
+        data_tests:
+          - unique
+          - not_null
+      - name: person_id
+        description: Patient identifier
+        data_tests:
+          - not_null
+
+  - name: int_tuva__immunization
+    description: >
+      Transforms Synthea immunizations to Tuva immunization input layer format.
+      CVX codes pass through directly.
+    columns:
+      - name: immunization_id
+        description: Unique immunization identifier (surrogate key)
+        data_tests:
+          - unique
+          - not_null
+      - name: person_id
+        description: Patient identifier
+        data_tests:
+          - not_null
+
+  - name: int_tuva__practitioner
+    description: >
+      Transforms Synthea providers to Tuva practitioner input layer format.
+      Note: NPI is null as Synthea doesn't include this identifier.
+    columns:
+      - name: practitioner_id
+        description: Unique practitioner identifier
+        data_tests:
+          - unique
+          - not_null
+
+  - name: int_tuva__location
+    description: >
+      Transforms Synthea organizations to Tuva location input layer format.
+      Note: NPI is null as Synthea doesn't include this identifier.
+    columns:
+      - name: location_id
+        description: Unique location identifier
+        data_tests:
+          - unique
+          - not_null
+```
+
+---
+
+## Implementation Order
+
+### Phase 1: Foundation (Day 1)
+
+1. Update `packages.yml` with Tuva package
+2. Run `dbt deps` to install
+3. Verify no conflicts
+
+### Phase 2: Seeds (Day 1)
+
+1. Create `seeds/tuva_mappings/` directory
+2. Create `encounter_type_mapping.csv`
+3. Create `loinc_category_mapping.csv`
+4. Run `dbt seed`
+
+### Phase 3: Staging Addition (Day 1)
+
+1. Create `stg_synthea__immunizations.sql`
+2. Add to `_synthea__models.yml`
+3. Run `dbt build --select stg_synthea__immunizations`
+
+### Phase 4: Connector Models (Days 2-3)
+
+Build in dependency order:
+
+1. `int_tuva__patient` (no dependencies)
+2. `int_tuva__location` (no dependencies)
+3. `int_tuva__practitioner` (no dependencies)
+4. `int_tuva__encounter` (depends on mapping seed)
+5. `int_tuva__condition` (depends on patient)
+6. `int_tuva__procedure` (depends on patient)
+7. `int_tuva__medication` (depends on patient)
+8. `int_tuva__observation` (depends on patient, LOINC seed)
+9. `int_tuva__lab_result` (depends on patient, LOINC seed)
+10. `int_tuva__immunization` (depends on patient)
+
+### Phase 5: Configuration (Day 3)
+
+1. Update `dbt_project.yml` with Tuva vars
+2. Run `dbt compile --select tuva_health.*`
+3. Verify compilation succeeds
+
+### Phase 6: Testing (Day 4)
+
+1. Create `_tuva_connector__models.yml`
+2. Run `dbt test --select tag:tuva_connector`
+3. Fix any failures
+
+---
+
+## Testing Strategy
+
+### Unit Tests (dbt tests)
+
+| Test Type | Coverage |
+|-----------|----------|
+| `unique` | All primary keys |
+| `not_null` | All primary keys, person_id |
+| `accepted_values` | sex, condition_status, data_source |
+| `relationships` | person_id to patient |
+
+### Integration Tests
+
+```bash
+# Full connector layer build
+dbt build --select tag:tuva_connector
+
+# Verify Tuva can compile against connectors
+dbt compile --select tuva_health.*
+
+# Row count verification
+dbt show --select int_tuva__patient --limit 5
+dbt show --select int_tuva__encounter --limit 5
+```
+
+### Validation Queries
+
+```sql
+-- Verify patient count matches
+select
+    'staging' as layer, count(*) as patients
+from {{ ref('stg_synthea__patients') }}
+union all
+select
+    'connector' as layer, count(*) as patients
+from {{ ref('int_tuva__patient') }};
+
+-- Verify observation split
+select
+    'total_obs' as category, count(*) as cnt
+from {{ ref('stg_synthea__observations') }}
+union all
+select
+    'vitals' as category, count(*) as cnt
+from {{ ref('int_tuva__observation') }}
+union all
+select
+    'labs' as category, count(*) as cnt
+from {{ ref('int_tuva__lab_result') }};
+```
+
+---
+
+## Risk Mitigation
+
+| Risk | Mitigation | Status |
+|------|------------|--------|
+| Package version conflict | Test in isolation branch first | Planned |
+| Missing LOINC codes | Start with common codes, extend as needed | Mitigated |
+| Tuva schema changes | Pin to specific version (0.15.3) | Mitigated |
+| Performance on observations | Use view materialization, index if needed | Planned |
+
+---
+
+## Open Questions Resolution
+
+| Question | Resolution |
+|----------|------------|
+| Use Tuva's terminology seeds or custom? | Use custom seeds for Synthea-specific mappings |
+| Placeholder for missing NPI? | Use `null` - Tuva handles missing values |
+| Observation/lab split method? | Use seed file with LOINC categories |
+
+---
+
+## Verification Checklist
+
+- [ ] `dbt deps` installs Tuva without errors
+- [ ] `dbt seed` loads mapping files
+- [ ] `dbt build --select stg_synthea__immunizations` succeeds
+- [ ] `dbt build --select tag:tuva_connector` succeeds (10 models)
+- [ ] `dbt test --select tag:tuva_connector` passes
+- [ ] `dbt compile --select tuva_health.*` succeeds
+- [ ] Documentation exists for all connector models
+- [ ] Row counts verified between staging and connectors
+
+---
+
+## Related Documents
+
+- **PRD**: [PRD-007-TUVA-FOUNDATION](./PRD-007-TUVA-FOUNDATION.md)
+- **Integration Plan**: [TUVA-INTEGRATION-PLAN](../plans/TUVA-INTEGRATION-PLAN.md)
+- **Coding Standards**: [DBT_CODING_STANDARDS](../reference/DBT_CODING_STANDARDS.md)
+
+---
+
+*Created: 2026-01-29*
+*Author: arch: (Architect)*


### PR DESCRIPTION
## Summary

Add comprehensive planning documents for Tuva Project integration, establishing the vision for healthcare analytics beyond v0.4.

Also includes: `dev.duckdb` added to `.gitignore`

## Specs Added

### PRDs (Product Requirements)
| PRD | Focus |
|-----|-------|
| PRD-007 | Tuva Foundation layer integration |
| PRD-008 | Clinical marts (quality measures, chronic conditions) |
| PRD-009 | Claims data acquisition strategy |
| PRD-010 | Claims connector implementation |
| PRD-011 | Financial marts (cost analysis, utilization) |

### Technical Design
- **TDD-007**: Tuva Foundation technical approach

### Planning
- **TUVA-INTEGRATION-PLAN.md**: Phased implementation roadmap

## Roadmap Vision

```
v0.4 (Current)     v0.5 (Tuva)           v0.6+ (Claims)
─────────────────► ──────────────────► ─────────────────►
Dimensional Models  Clinical Analytics   Financial Analytics
dim_*, fct_*        Quality Measures     Cost Analysis
                    Chronic Conditions   Utilization
```

## Test plan
- [x] Markdown lint passes
- [x] All files valid markdown
- [ ] Review specs for completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)