### PR TITLE
docs(specs): add Workflow Hub to PRD-014

### DIFF
--- a/docs/specs/FUTURE_FEATURES.md
+++ b/docs/specs/FUTURE_FEATURES.md
@@ -33,6 +33,85 @@ The metrics foundation feature has been promoted to active planning. See [PRD-01
 
 ---
 
+## Agent System & Workflow Tooling
+
+### Visual Orchestration Tool
+
+**Status**: Future Consideration (Post-MVP Hub)
+**Origin**: Team Consultation Report (2026-01-30)
+
+The Workflow Hub (PRD-014) focuses on aggregate dashboard view for session continuity. A separate **Visual Orchestration Tool** would provide real-time workflow visualization and control.
+
+| Feature | Description | Complexity | Priority |
+|---------|-------------|------------|----------|
+| Real-time workflow graph | Live Mermaid/D3 visualization of agent handoffs | High | Medium |
+| Step-through debugging | Pause/resume orchestration at phase gates | High | Low |
+| Branch visualization | Show decision points and paths taken | Medium | Medium |
+| Workflow templates | Visual workflow designer for custom pipelines | High | Low |
+| Execution replay | Replay past orchestrations with timeline scrubbing | Medium | Low |
+
+**Relationship to Hub**: Hub = aggregate status (where am I?), Orchestration Tool = live process view (what's happening now?)
+
+### When to Evaluate
+
+- After Workflow Hub MVP proves value
+- When orchestration debugging becomes a pain point
+- When Chris wants to design custom agent workflows visually
+
+---
+
+### Git Worktree Management Enhancements
+
+**Status**: Future Consideration (Post-MVP)
+**Origin**: Team Consultation Report (2026-01-30)
+
+The MVP Workflow Hub focuses on current worktree context. Future enhancements would provide rich cross-worktree capabilities.
+
+| Feature | Description | Complexity | Priority |
+|---------|-------------|------------|----------|
+| Cross-worktree visibility | See agent activity across all worktrees simultaneously | Medium | High |
+| Worktree-aware SESSION_SUMMARY | Per-worktree session tracking with global aggregation | Medium | Medium |
+| Conflict prediction | AI-based prediction of merge conflicts before they happen | High | Medium |
+| Worktree templates | Pre-configured worktree setups for common patterns | Low | Low |
+| Auto-cleanup | Automatically archive/remove worktrees after PR merge | Low | Medium |
+| Worktree sync status | Real-time sync indicators across terminals | Medium | Low |
+
+**MVP Scope**: Current worktree only, summary view linking to Worktree Coordinator
+
+**Future Scope**: Full cross-worktree orchestration with conflict prevention
+
+---
+
+### UI/UX Design Upgrade
+
+**Status**: Future Consideration (Post-MVP Feedback)
+**Origin**: Team Consultation Report (2026-01-30)
+
+The MVP prioritizes enabling capabilities over polished design. Future iterations will focus on UI/UX improvements based on actual usage feedback.
+
+| Feature | Description | Complexity | Priority |
+|---------|-------------|------------|----------|
+| Design system | Consistent component library across all playgrounds | Medium | High |
+| User feedback collection | Built-in feedback mechanism in playgrounds | Low | High |
+| Accessibility audit | WCAG compliance review and fixes | Medium | Medium |
+| Responsive design | Mobile/tablet support for playgrounds | Medium | Low |
+| Keyboard shortcuts | Power user navigation | Low | Medium |
+| Theme customization | Beyond light/dark mode | Low | Low |
+| Animation polish | Smooth transitions, loading states | Low | Low |
+| Onboarding flow | First-time user guidance | Medium | Medium |
+
+**MVP Focus**: Functional UI that works
+**Future Focus**: Delightful UI based on user feedback
+
+### Feedback Collection Strategy
+
+1. MVP includes simple feedback button ("Was this helpful?")
+2. Collect pain points during usage
+3. Prioritize UI/UX improvements based on frequency of issues
+4. v0.7+ design sprint to address top feedback items
+
+---
+
 ## Warehouse Evaluation for Semantic Layer
 
 **Status**: Future Consideration
@@ -190,4 +269,4 @@ Move to PRD when:
 
 *This is a living backlog. Ideas may be added, modified, or removed as the project evolves.*
 
-*Last Updated: 2026-01-29*
+*Last Updated: 2026-01-30*

--- a/docs/specs/PRD-014-PLAYGROUND-TOOLS.md
+++ b/docs/specs/PRD-014-PLAYGROUND-TOOLS.md
@@ -6,14 +6,14 @@ version: 0.6.0
 status: draft
 author: pm
 created: 2026-01-29
-last_updated: 2026-01-29
+last_updated: 2026-01-30
 ---
 
 ## Overview
 
 ### Executive Summary
 
-This PRD defines five interactive playground tools designed to enhance learning, development visibility, and workflow efficiency in the dbt-playground project. These tools transform implicit system knowledge into explorable, visual interfaces that accelerate onboarding, debugging, and feature development.
+This PRD defines seven interactive playground tools designed to enhance learning, development visibility, and workflow efficiency in the dbt-playground project. These tools transform implicit system knowledge into explorable, visual interfaces that accelerate onboarding, debugging, and feature development.
 
 ### Tool Overview
 
@@ -25,6 +25,7 @@ This PRD defines five interactive playground tools designed to enhance learning,
 | 4 | Healthcare Data Schema Explorer | Browse Synthea data structure interactively | v0.6.1 |
 | 5 | Mermaid Diagram Designer | Create/edit/export architecture & workflow diagrams | v0.6.0 |
 | 6 | Dashboard Mockup Builder | Design analytics dashboards visually | v0.6.3 |
+| 7 | Workflow Hub | Central command center for session continuity and agent visibility | v0.6.0 |
 
 ### Success Metrics (Global)
 
@@ -32,6 +33,7 @@ This PRD defines five interactive playground tools designed to enhance learning,
 - New contributors productive within 1 session
 - Zero cross-worktree conflicts after Coordinator adoption
 - Agent workflow failures diagnosed in <2 minutes
+- Session resume in <60 seconds via Workflow Hub
 
 ---
 
@@ -52,6 +54,7 @@ Visual tools for learning and development. Launch via commands or explore in the
 
 | Playground | Command | Purpose |
 |------------|---------|---------|
+| Workflow Hub | `/playground:hub` | Central command center, session resume |
 | Agent Visualizer | `/playground:agents` | View agent workflows and handoffs |
 | Worktree Coordinator | `/playground:worktrees` | Manage parallel sessions |
 | Lineage Explorer | `/playground:lineage` | Trace dbt data flow |
@@ -59,7 +62,7 @@ Visual tools for learning and development. Launch via commands or explore in the
 | Mermaid Diagram Designer | `/playground:mermaid` | Create architecture diagrams visually |
 | Dashboard Builder | `/playground:dashboards` | Mock analytics layouts |
 
-Quick start: Run `/playground` to see available tools.
+Quick start: Run `/playground` to open the Workflow Hub (default entry point).
 ```
 
 #### 2. Agent Suggestions
@@ -68,6 +71,7 @@ Agents should suggest relevant playgrounds contextually:
 
 | Agent | Suggests | When |
 |-------|----------|------|
+| Supervisor | Workflow Hub | Starting or resuming a session |
 | Supervisor | Worktree Coordinator | Creating parallel work tracks |
 | Supervisor | Agent Visualizer | Explaining workflow phases |
 | Data Modeler | Schema Explorer | Designing new models |
@@ -79,7 +83,8 @@ Agents should suggest relevant playgrounds contextually:
 New slash commands for playground access:
 
 ```text
-/playground                    # List all playgrounds
+/playground                    # Open Workflow Hub (default entry point)
+/playground:hub                # Open Workflow Hub explicitly
 /playground:agents [workflow]  # Launch Agent Visualizer
 /playground:worktrees          # Launch Worktree Coordinator
 /playground:lineage [model]    # Launch Lineage Explorer
@@ -107,6 +112,7 @@ playgrounds/
 │   ├── ui-framework.js       # Shared UI components
 │   ├── state-manager.js      # Reactive state management
 │   └── api-bridge.js         # CLI/Web communication
+├── workflow-hub.html         # Entry point, command center
 ├── agent-visualizer/
 ├── worktree-coordinator/
 ├── lineage-explorer/
@@ -1174,12 +1180,260 @@ Share mockups in multiple formats.
 
 ---
 
+## Playground 7: Workflow Hub
+
+### Value Proposition
+
+Working across multiple sessions, features, and git worktrees creates fragmented context:
+
+- What was I working on when the session ended?
+- What phase is each feature in?
+- What have agents been doing?
+- How do I resume quickly after days away?
+
+The Workflow Hub provides a **central command center** that answers: "Where was I, and what should I do next?"
+
+### User Personas
+
+| Persona | Use Case | Frequency |
+|---------|----------|-----------|
+| Returning User | Resume work after days away | Per session start |
+| Multi-Session User | Track parallel features across worktrees | Daily |
+| Learner | Understand what agents have been doing | Weekly |
+| Supervisor | Get session context for handoff | Per session |
+
+### Core Features
+
+#### F7.1: Quick Resume Panel
+
+Display the most recent session summary for instant context recovery.
+
+```text
+┌────────────────────────────────────────────────────────────────────────┐
+│  QUICK RESUME                                                          │
+│  ═══════════                                                           │
+│                                                                        │
+│  Last Session: 2026-01-30                                              │
+│  Active Track: feat/agent-context-management                           │
+│  Last Action: PRD + TDD complete, 8 tasks ready                        │
+│  Next Action: Begin Phase 1 - AGENT_REPORTS structure                  │
+│                                                                        │
+│  Decisions Made:                                                       │
+│  - Adopted inter-agent report pattern from Claudie blog                │
+│  - Deferred vector search to v1.0+                                     │
+│                                                                        │
+│  Open Questions:                                                       │
+│  - None blocking                                                       │
+│                                                                        │
+│                                                              [Resume →] │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+**Acceptance Criteria**:
+
+- [ ] Parses most recent `temp/SESSION_SUMMARY_*.md` file
+- [ ] Displays Active Track, Last Action, Next Action
+- [ ] Shows key decisions made
+- [ ] Lists open questions/blockers
+- [ ] "Resume" button copies supervisor resume context
+
+#### F7.2: Active Tracks View
+
+Display all workflow tracks from `temp/WORKFLOW_STATE.md`.
+
+```text
+┌──────────────────────┐  ┌──────────────────────┐  ┌──────────────────┐
+│ feat/agent-context   │  │ feat/playground-tools│  │ main             │
+│ ───────────────────  │  │ ────────────────────  │  │ ────             │
+│ Phase: READY         │  │ Phase: QUEUED        │  │ v0.5.0 RELEASED  │
+│ PRD: ✓  TDD: ✓       │  │ PRD: ✓  TDD: -       │  │ Clean            │
+│ 8 tasks pending      │  │ Waiting for v0.6     │  │                  │
+│                      │  │                      │  │                  │
+│ [Open] [Details]     │  │ [Open] [Details]     │  │ [Open]           │
+└──────────────────────┘  └──────────────────────┘  └──────────────────┘
+```
+
+**Acceptance Criteria**:
+
+- [ ] Parses `temp/WORKFLOW_STATE.md` YAML and markdown
+- [ ] Shows phase status per track (ACTIVE, QUEUED, COMPLETE)
+- [ ] Displays artifact checklist status (PRD, TDD, Tests, etc.)
+- [ ] Expands to show full track details
+- [ ] Distinguishes blocked vs. ready tracks
+
+#### F7.3: Agent Activity Timeline
+
+Show recent agent reports from `temp/AGENT_REPORTS/`.
+
+```text
+┌────────────────────────────────────────────────────────────────────────┐
+│  RECENT AGENT ACTIVITY                             [→ Agent Visualizer] │
+│  ═════════════════════                                                  │
+│                                                                        │
+│  2026-01-30 23:45  Supervisor    v0.5.0 release complete               │
+│  2026-01-30 23:30  Code Reviewer PR #54 approved (Grade A)             │
+│  2026-01-30 23:25  Security      PR #54 approved (Low Risk)            │
+│  2026-01-30 20:00  PM            PRD-016 created                       │
+│  2026-01-30 19:45  Architect     TDD-016 created                       │
+│                                                                        │
+│                                                        [Show More ↓]   │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+**Acceptance Criteria**:
+
+- [ ] Scans `temp/AGENT_REPORTS/[feature]/` directories
+- [ ] Extracts timestamp and summary from report YAML frontmatter
+- [ ] Displays chronologically (most recent first)
+- [ ] Limits to 10 entries with "Show More" expansion
+- [ ] Links to Agent Visualizer for full workflow view
+
+#### F7.4: Git Worktree Summary
+
+Display worktree status at a glance.
+
+```text
+┌────────────────────────────────────────────────────────────────────────┐
+│  GIT WORKTREES                                   [→ Worktree Coord.]   │
+│  ═════════════                                                          │
+│                                                                        │
+│  ● main: /Users/cmbays/Documents/claude/dbt-playground                 │
+│    Status: ✓ Clean | ✓ Up to date with origin                         │
+│                                                                        │
+│  ○ No active worktrees                                                 │
+│    (5 stale branches detected)                                         │
+│                                                                        │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+**Acceptance Criteria**:
+
+- [ ] Parses `git worktree list` output
+- [ ] Shows clean/dirty status per worktree
+- [ ] Indicates ahead/behind main
+- [ ] Links to Worktree Coordinator for full management
+- [ ] Flags stale branches
+
+#### F7.5: Playground Navigation
+
+Quick access to all other playgrounds.
+
+```text
+┌────────────────────────────────────────────────────────────────────────┐
+│  PLAYGROUNDS                                                           │
+│  ═══════════                                                           │
+│                                                                        │
+│  [Agents] [Worktrees] [Schema] [Lineage] [Dashboards] [Mermaid]       │
+│                                                                        │
+│  ○ Schema Explorer: Not yet built                                      │
+│  ○ Lineage Explorer: Not yet built                                     │
+│                                                                        │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+**Acceptance Criteria**:
+
+- [ ] Shows buttons for all available playgrounds
+- [ ] Indicates which playgrounds are built vs. planned
+- [ ] Opens playground in new tab on click
+
+### Data Sources
+
+| Section | Source | Format |
+|---------|--------|--------|
+| Quick Resume | `temp/SESSION_SUMMARY_*.md` | Markdown with YAML frontmatter |
+| Active Tracks | `temp/WORKFLOW_STATE.md` | YAML frontmatter + markdown |
+| Agent Activity | `temp/AGENT_REPORTS/[feature]/*.md` | Directory scan + YAML frontmatter |
+| Worktrees | `git worktree list` | CLI output (or JSON export) |
+
+### Data Loading Strategy
+
+Since playgrounds are static HTML (no server):
+
+1. **Primary (MVP)**: Drag-drop or paste file contents
+2. **Secondary**: Export script generates `temp/hub-data.json`
+3. **Tertiary**: LocalStorage cache for instant display on return
+
+```bash
+# Power user: Export state to JSON
+uv run python scripts/export-hub-data.py
+# Creates temp/hub-data.json for Hub to load
+```
+
+### Integration Points
+
+| System | Integration |
+|--------|-------------|
+| temp/WORKFLOW_STATE.md | Track status display |
+| temp/SESSION_SUMMARY_*.md | Quick resume content |
+| temp/AGENT_REPORTS/ | Agent activity timeline |
+| PRD-016 (Agent Context Management) | Creates the artifacts Hub visualizes |
+| Other playgrounds | Deep links for detailed views |
+
+### Success Criteria
+
+- Session resume in <60 seconds (vs. 5+ minutes reading files)
+- All active tracks visible at a glance
+- Agent activity provides audit trail
+- Entry point to all other playgrounds
+
+### Technical Notes
+
+**Implementation**: Single HTML file (`playgrounds/workflow-hub.html`).
+
+**Parsing**: JavaScript parsers for YAML frontmatter and markdown sections.
+
+**Storage**: LocalStorage for caching parsed state between visits.
+
+**Relationship to Other Playgrounds**:
+
+- Hub = aggregate dashboard (where am I?)
+- Agent Visualizer = workflow detail (what's the process?)
+- Worktree Coordinator = git detail (what branches exist?)
+
+### Wireframe
+
+```text
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  WORKFLOW HUB                                        [Refresh] [Settings]    │
+│  dbt-playground | v0.5.0                             Last: 2h ago            │
+├──────────────────────────────────────────────────────────────────────────────┤
+│                                                                              │
+│  QUICK RESUME                                                                │
+│  ┌────────────────────────────────────────────────────────────────────────┐  │
+│  │  Last Session: 2026-01-30                                              │  │
+│  │  Active Track: feat/agent-context-management                           │  │
+│  │  Last Action: PRD + TDD complete                                       │  │
+│  │  Next Action: Begin Phase 1                                [Resume →]  │  │
+│  └────────────────────────────────────────────────────────────────────────┘  │
+│                                                                              │
+├──────────────────────────────────────────────────────────────────────────────┤
+│  ACTIVE TRACKS                                                               │
+│  ┌────────────┐  ┌────────────┐  ┌────────────┐                             │
+│  │ feat/...   │  │ feat/...   │  │ main       │                             │
+│  │ READY      │  │ QUEUED     │  │ v0.5.0     │                             │
+│  └────────────┘  └────────────┘  └────────────┘                             │
+├──────────────────────────────────────────────────────────────────────────────┤
+│  WORKTREES                                             [→ Coordinator]       │
+│  main: Clean | No active worktrees                                          │
+├──────────────────────────────────────────────────────────────────────────────┤
+│  AGENT ACTIVITY                                        [→ Visualizer]        │
+│  23:45 Supervisor: v0.5.0 release | 23:30 Code Reviewer: Grade A            │
+├──────────────────────────────────────────────────────────────────────────────┤
+│  PLAYGROUNDS                                                                 │
+│  [Agents] [Worktrees] [Schema] [Lineage] [Dashboards] [Mermaid]             │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
 ## Priority and Dependencies
 
 ### Build Order
 
 ```text
 Phase 1 (v0.6.0) - Foundation
+├── 7. Workflow Hub (entry point, command center, session continuity)
 ├── 2. Git Worktree Coordinator (unblocks parallel development)
 ├── 5. Mermaid Diagram Designer (simplest, improves documentation immediately)
 
@@ -1198,6 +1452,7 @@ Phase 4 (v0.6.3) - Design
 
 | Playground | Depends On | Enables |
 |------------|------------|---------|
+| Workflow Hub | PRD-016 artifacts, WORKFLOW_STATE.md | Entry point, session continuity |
 | Worktree Coordinator | git, gh CLI | Parallel development |
 | Agent Visualizer | WORKFLOW_STATE.md | Workflow debugging |
 | Mermaid Designer | mermaid.js library | Architecture documentation |
@@ -1209,12 +1464,18 @@ Phase 4 (v0.6.3) - Design
 
 | Playground | Complexity | Estimated Hours | Risk |
 |------------|------------|-----------------|------|
+| Workflow Hub | Low-Medium | 8-24 | Low |
 | Worktree Coordinator | Medium | 16-24 | Low |
 | Mermaid Designer | Low | 8-12 | Low |
 | Agent Visualizer | Low-Medium | 12-16 | Low |
 | Schema Explorer | Medium | 20-28 | Low |
 | Lineage Explorer | Medium-High | 24-32 | Medium |
 | Dashboard Builder | High | 40-60 | Medium |
+
+**Workflow Hub Effort Breakdown**:
+
+- MVP (8 hrs): Quick Resume + Active Tracks + Playground navigation
+- Full (24 hrs): + Agent reports browser + worktree status + export script
 
 ---
 
@@ -1272,6 +1533,12 @@ Phase 4 (v0.6.3) - Design
 4. **BI Tool Export**: Should Dashboard Builder export to specific BI tools?
    - Recommendation: Defer, focus on mockups and dbt YAML
 
+5. **Hub Entry Point Behavior**: Should `/playground` default to Hub or show a menu?
+   - Recommendation: Default to Hub with navigation to other playgrounds
+
+6. **Hub Data Loading (MVP)**: Accept manual paste or require export script?
+   - Recommendation: Manual paste + LocalStorage for MVP, export script for power users
+
 ---
 
 ## References
@@ -1280,6 +1547,8 @@ Phase 4 (v0.6.3) - Design
 - [AGENTS.md](/Users/cmbays/Documents/claude/dbt-playground/.claude/agents/AGENTS.md) - Agent orchestration
 - [GIT-WORKTREE-WORKFLOW.md](/Users/cmbays/Documents/claude/dbt-playground/docs/for_chris/GIT-WORKTREE-WORKFLOW.md) - Worktree documentation
 - [PRD-004-DIMENSIONAL-MODELS.md](/Users/cmbays/Documents/claude/dbt-playground/docs/specs/PRD-004-DIMENSIONAL-MODELS.md) - Model structure
+- [PRD-016-AGENT-CONTEXT-MANAGEMENT.md](/Users/cmbays/Documents/claude/dbt-playground/docs/specs/PRD-016-AGENT-CONTEXT-MANAGEMENT.md) - Agent context artifacts (Workflow Hub data source)
+- [TEAM_CONSULTATION_REPORT.md](/Users/cmbays/Documents/claude/dbt-playground/temp/AGENT_REPORTS/workflow-hub/TEAM_CONSULTATION_REPORT.md) - Team consultation for Workflow Hub
 - [dbt docs](https://docs.getdbt.com/) - dbt reference
 
 ---


### PR DESCRIPTION
## Summary

- Add Workflow Hub as Playground 7 in PRD-014-PLAYGROUND-TOOLS
- Define features F7.1-F7.5 for session continuity and agent visibility
- Add future features backlog items for post-MVP enhancements
- Clarify soft dependency model with PRD-016

## Changes

### PRD-014-PLAYGROUND-TOOLS.md
- Added Workflow Hub as new playground tool (#7)
- Defined 5 features: Quick Resume, Active Tracks, Agent Activity, Worktree Summary, Navigation
- Updated build order to prioritize Hub in Phase 1
- Added Hub to dependency matrix and effort estimates

### FUTURE_FEATURES.md
- Added Visual Orchestration Tool (real-time workflow visualization)
- Added Git Worktree Management Enhancements
- Added UI/UX Design Upgrade considerations

## Context

Based on full team consultation with all agents (PM, Architect, Sage, Developer, dbt-Developer, dbt-Tester, Git-Master, Code-Reviewer). Consultation report saved in `temp/AGENT_REPORTS/workflow-hub/`.

## Test plan

- [ ] Specs reviewed for consistency
- [ ] No conflicts with existing playground definitions
- [ ] Future features properly scoped as post-MVP

🤖 Generated with [Claude Code](https://claude.com/claude-code)