### PR TITLE
docs: add competitive ideation process summary

### DIFF
--- a/docs/for_chris/COMPETITIVE_IDEATION_CYCLES.md
+++ b/docs/for_chris/COMPETITIVE_IDEATION_CYCLES.md
@@ -1,0 +1,221 @@
+# What Just Happened: Competitive Ideation for Workflow Chronicle
+
+**For**: Chris (Project Owner)
+**From**: Sage
+**Date**: 2026-01-30
+**Topic**: How 8 simulated teams designed your workflow history feature
+
+---
+
+## What This Is
+
+You just ran a **competitive ideation experiment**. Instead of having one agent design the Workflow Chronicle feature, you had Claude simulate 8 independent teams working in parallel, each with a different focus area. Then a "council" synthesized the best ideas into a unified product concept.
+
+This is essentially crowdsourcing product design from parallel AI perspectives.
+
+---
+
+## The Problem We Were Solving
+
+You wanted a **Workflow State History** feature for the Playground Hub that would:
+
+1. Show how workflow state changes over time
+2. Help you understand how agent teams use workflow state
+3. Enable iterative improvement through visibility
+4. Provide simple metrics to measure feature improvements
+
+The core questions were about **standards adherence**, **context management**, and **signal vs. noise** in development documentation.
+
+---
+
+## How It Worked
+
+### The Process
+
+**Round 1**: 8 teams worked independently on their assigned focus areas:
+
+| Team | Focus Area |
+|------|------------|
+| Team 1 | Observability and Real-Time Monitoring |
+| Team 2 | Learning and Improvement |
+| Team 3 | Standards and Quality Gates |
+| Team 4 | Context Preservation |
+| Team 5 | UX and Interaction Design |
+| Team 6 | Multi-Agent Coordination |
+| Team 7 | Metrics and Analytics |
+| Team 8 | Predictive and Adaptive Systems |
+
+**Round 2**: Teams critiqued their own work and improved it.
+
+**Round 3**: Final iteration with cross-team awareness.
+
+**Council Synthesis**: A council reviewed all 8 proposals and extracted the best ideas into a unified product.
+
+### What Made It "Competitive"
+
+Teams did not see each other's work until the synthesis phase. This meant:
+
+- No groupthink - teams came to similar conclusions independently
+- Novel ideas emerged from different perspectives
+- When 6 out of 8 teams proposed the same thing, that's strong validation
+
+---
+
+## Key Results
+
+### The Product: Workflow Chronicle
+
+**Tagline**: *"Remember everything. Learn what matters."*
+
+The council synthesized everything into a feature called **Workflow Chronicle** with three core principles:
+
+| Principle | Question Answered |
+|-----------|-------------------|
+| **Recall** | What happened? |
+| **Reflect** | What patterns emerged? |
+| **Resume** | How do I get back to work fast? |
+
+### MVP Recommendation: 6 Features in 4-6 Weeks
+
+| Feature | What It Does | Source Team |
+|---------|--------------|-------------|
+| **Event Log + Git Parser** | Zero-setup timeline from git history alone | Team 1 |
+| **Quick Resume Panel** | Get back to productive work in 5 seconds | Teams 4, 5 |
+| **Phase Duration + Health Pulse** | Single 0-100 health score with drill-down | Team 7 |
+| **Negative Space Registry** | Track what you decided NOT to do (and why) | Team 4 |
+| **Stratified Timeline Playground** | Visual interface with time horizontal, depth vertical | Team 5 |
+| **Standards Score with Ratchet** | Quality baseline that can only go up, never down | Teams 3, 7 |
+
+### Consensus Themes (What Multiple Teams Agreed On)
+
+These appeared in 4-8 of the 8 teams, so they're considered essential:
+
+1. **Immutable Event Log** (7/8 teams) - Append-only history of what happened
+2. **Phase Duration Tracking** (7/8 teams) - How long does each workflow phase take?
+3. **Pattern Detection** (6/8 teams) - Find recurring patterns in your workflow
+4. **Quick Resume** (6/8 teams) - 30-second context recovery when returning to work
+5. **Decision Rationale Capture** (5/8 teams) - Record WHY decisions were made
+6. **Agent + Human Dual-Mode** (5/8 teams) - Interfaces that work for both you and Claude
+
+---
+
+## What Makes This Interesting
+
+### Novel Ideas That Emerged
+
+**1. Git as Telemetry (Team 1)**
+
+The most practical insight: You already have workflow history. It's called git.
+
+Every commit captures who, what, when, and why. Parse conventional commit messages and Co-Authored-By patterns, and you can reconstruct a development timeline without adding any new instrumentation. Zero setup, immediate value.
+
+```bash
+# This could work TODAY
+uv run scripts/workflow-timeline.py --since="8 hours ago"
+```
+
+**2. Negative Space Registry (Team 4)**
+
+This is the idea I found most undervalued. A structured record of decisions you DIDN'T make and why.
+
+Example:
+
+```yaml
+- question: "Should we use Snowflake instead of DuckDB?"
+  answer: NO
+  rationale: "Learning project, cost matters, DuckDB sufficient"
+  reconsidering_trigger: "If data exceeds 10GB"
+```
+
+The key innovation is the `reconsidering_trigger` field - it tells future sessions WHEN a rejected decision should be revisited. This prevents re-litigating the same decisions while allowing them to be reopened when conditions change.
+
+**3. The Health Pulse (Team 7)**
+
+Instead of 20 metrics on a dashboard, one number: 0-100 workflow health.
+
+```
+HEALTH PULSE: 73 [=======---] FAIR
+Trend: +5 from last week
+Primary Driver: Phase Duration (dragging down)
+```
+
+The insight: Always show what's dragging you down and what to focus on. One number with full drill-down capability.
+
+**4. Cognitive Resume Protocol (Team 4)**
+
+The 30-second resume target is a machine metric. But returning to work is a psychological experience. Team 4 proposed a sequence that addresses human cognition:
+
+1. **Anchor** (3 sec): Where am I?
+2. **Orientation** (10 sec): What was I doing?
+3. **Momentum** (30 sec): What do I need to know to take the next step?
+4. **Confidence Check**: Does this match your mental model?
+
+**5. Failure Herbarium (Team 2)**
+
+Most learning systems focus on success patterns. Team 2 proposed cataloging failures systematically, with causal context, detection signals, and prevention strategies. Anti-patterns as a first-class artifact.
+
+### Ideas That Were Rejected
+
+The council also identified over-engineering:
+
+- **Cryptographic Proof-of-Quality** - Signing artifacts with hashes. Adds complexity without proportional value for a solo project.
+- **Replay Theater** - Playing back development sessions as video. Impressive but low-utility when 30-second resume solves the actual problem.
+- **What-If Simulator** - Simulating alternative workflow paths. Requires causal modeling we can't reliably do.
+- **Full Distributed Tracing** - Enterprise-grade OpenTelemetry-style tracing. Overkill. Git-as-telemetry provides sufficient signal.
+
+---
+
+## Next Steps
+
+You have three options:
+
+### Option A: Create a Formal PRD
+
+Draft PRD-017: Workflow Chronicle with acceptance criteria and implementation estimates. The synthesis document essentially IS a pre-PRD.
+
+### Option B: Prototype a Single Feature
+
+Pick the most valuable feature and build it. My recommendation: **Git Parser + Quick Resume**. Zero new instrumentation, immediate value, validates the core concept.
+
+### Option C: Iterate on Specific Ideas
+
+Dive deeper into a particular team's proposal. Team 1's zero-setup philosophy or Team 4's negative space concept might warrant more exploration.
+
+---
+
+## Reading Guide
+
+If you want to go deeper, here's what to read:
+
+| File | What It Contains | Read If... |
+|------|------------------|------------|
+| `council/SYNTHESIS.md` | Complete synthesis with MVP details | You want the full unified product concept |
+| `team-1/IDEAS.md` | Git as telemetry, three-tier observability | You like the zero-setup approach |
+| `team-4/IDEAS.md` | Negative space, cognitive resume | You care about context preservation |
+| `team-7/IDEAS.md` | Health Pulse, metrics pyramid | You want the measurement philosophy |
+| `WORKFLOW_CHRONICLE_INDEX.md` | Summary of all teams with highlights | You want the executive overview |
+
+### Total Research Output
+
+- 8 team proposals + council synthesis
+- ~105KB of documentation
+- 3 competitive cycles with self-critique
+- 6 MVP features identified
+- 10+ ideas deferred to v2
+- 10+ ideas rejected as over-engineering
+
+---
+
+## My Take (as Sage)
+
+This experiment validated something important: **independent parallel ideation surfaces better ideas than sequential refinement**.
+
+When 7 out of 8 teams independently propose immutable event logs, that's not groupthink - that's convergent validation. When only 1 team proposes negative space documentation, that's a novel insight that might have been missed in a single-threaded design process.
+
+The "Git as Telemetry" insight is particularly valuable for your philosophy of starting simple. You don't need to build a telemetry system - you already have one. You just need to read it properly.
+
+Worth doing again for future complex features? I'd say yes.
+
+---
+
+*Generated by Sage from the competitive ideation artifacts*


### PR DESCRIPTION
## Summary

- Adds `docs/for_chris/COMPETITIVE_IDEATION_CYCLES.md` documenting the 8-team competitive ideation methodology
- Explains how the Workflow Chronicle feature was designed through parallel AI teams
- Captures key insights: git-as-telemetry, negative space registry, health pulse metrics

## Context

This summarizes the competitive ideation experiment that ran 8 simulated teams in parallel to design the Workflow Chronicle feature. The working files remain in `temp/competitive-ideation-cycle-2/`.

## Test plan

- [x] File renders correctly in GitHub
- [x] Links to related temp files are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)