### PR TITLE
feat: enhance repo-research with parallel specialist mode

### DIFF
--- a/.claude/commands/repo-research.md
+++ b/.claude/commands/repo-research.md
@@ -5,18 +5,48 @@ Research an external repository and generate a learnings report for pm: and arch
 ## Usage
 
 ```
-/repo-research <github-url> [--depth=quick|standard|deep] [--focus="research question"]
+/repo-research <github-url> [options]
 ```
+
+### Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--depth` | Research depth: `quick`, `standard`, `deep` | `standard` |
+| `--focus` | Research question or specialist scope | none |
+| `--parallel` | Enable multi-agent specialist research | off (on for deep) |
+| `--specialists` | Specific specialists: `architect,security-reviewer,code-reviewer` | all (when parallel) |
+| `--council` | Trigger council deliberation after research | off |
+| `--skip-handoff` | Generate report without handoff messages | off |
 
 ## Examples
 
-```
+```bash
+# Standard single-agent research
 /repo-research https://github.com/dbt-labs/dbt-core
+
+# Deep research with focus question
 /repo-research https://github.com/dbt-labs/dbt-utils --depth=deep --focus="macro patterns"
+
+# Quick evaluation
 /repo-research https://github.com/example/dbt-project --depth=quick
+
+# Parallel specialist mode (standard depth)
+/repo-research https://github.com/dbt-labs/dbt-core --parallel
+
+# Deep research (parallel is automatic)
+/repo-research https://github.com/dbt-labs/dbt-core --depth=deep
+
+# Parallel with specific specialists only
+/repo-research https://github.com/owner/repo --parallel --specialists=architect,security-reviewer
+
+# Full workflow with council deliberation
+/repo-research https://github.com/owner/repo --depth=deep --council
 ```
 
 ## Workflow
+
+### Standard Mode (Single Agent)
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -59,6 +89,61 @@ Research an external repository and generate a learnings report for pm: and arch
 │  → arch: Architecture patterns, technical decisions, TDDs   │
 └─────────────────────────────────────────────────────────────┘
 ```
+
+### Parallel Mode (Multi-Agent)
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  MASTER SAGE                                                    │
+│                                                                 │
+│  1. Parse URL → derive repo-name (owner-repo)                   │
+│  2. Create artifact folder: temp/AGENT_REPORTS/[repo-name]/     │
+│  3. Spawn specialists in parallel:                              │
+│                                                                 │
+│     ┌─────────────────┬─────────────────┬─────────────────┐    │
+│     │   ARCHITECT     │   SECURITY      │   CODE QUALITY  │    │
+│     │   --focus=arch  │   --focus=sec   │   --focus=qual  │    │
+│     │                 │                 │                 │    │
+│     │  • Structure    │  • Dependencies │  • Test coverage│    │
+│     │  • Patterns     │  • Vulnerabilty │  • Documentation│    │
+│     │  • Data flow    │  • Auth patterns│  • Maintainabil │    │
+│     │  • Scalability  │  • Data handling│  • Code standard│    │
+│     │                 │                 │                 │    │
+│     │  ARCHITECT_     │  SECURITY_      │  QUALITY_       │    │
+│     │  FOCUS.md       │  FOCUS.md       │  FOCUS.md       │    │
+│     └─────────────────┴─────────────────┴─────────────────┘    │
+│                                                                 │
+│  4. Wait for specialists to complete                            │
+│  5. Read all specialist reports                                 │
+│  6. Synthesize master report: RESEARCH_MASTER.md                │
+│     - Aggregate metrics and findings                            │
+│     - Identify convergent/divergent perspectives                │
+│     - Build combined risk matrix                                │
+│     - Prioritize recommendations by domain                      │
+│                                                                 │
+│  7. (Optional) Council handoff if --council                     │
+├─────────────────────────────────────────────────────────────────┤
+│  OUTPUT: temp/AGENT_REPORTS/[repo-name]/                        │
+│          ├── RESEARCH_MASTER.md                                 │
+│          ├── ARCHITECT_FOCUS.md                                 │
+│          ├── SECURITY_FOCUS.md                                  │
+│          └── QUALITY_FOCUS.md                                   │
+├─────────────────────────────────────────────────────────────────┤
+│  HANDOFF OPTIONS                                                │
+│                                                                 │
+│  → pm:      Feature opportunities from all perspectives         │
+│  → arch:    Architecture patterns with security/quality input   │
+│  → council: Full deliberation on diverse specialist findings    │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Depth + Parallel Matrix
+
+| Depth | Default Behavior | Parallel Available | Specialists |
+|-------|------------------|-------------------|-------------|
+| `quick` | Sage only | No | 0 |
+| `standard` | Sage only | Yes (`--parallel`) | 0-2 |
+| `deep` | Sage + specialists | Yes (default on) | 3 (full team) |
 
 ## Depth Levels
 
@@ -103,17 +188,31 @@ After research completes, Sage provides handoff messages for:
 - TDD candidates
 - Technical concerns and tradeoffs
 
-## Options
+## Options Reference
 
-| Option | Description |
-|--------|-------------|
-| `--depth` | Research depth: quick, standard, deep |
-| `--focus` | Specific research question or area |
-| `--skip-handoff` | Generate report without handoff messages |
+| Option | Description | Values |
+|--------|-------------|--------|
+| `--depth` | Research depth | `quick`, `standard`, `deep` |
+| `--focus` | Research question or specialist scope | string or `architecture`, `security`, `quality` |
+| `--parallel` | Enable multi-agent specialist research | flag |
+| `--specialists` | Specific specialists to include | `architect`, `security-reviewer`, `code-reviewer` |
+| `--council` | Trigger council deliberation after research | flag |
+| `--skip-handoff` | Generate report without handoff messages | flag |
+
+## Output Locations
+
+| Mode | Output Path |
+|------|-------------|
+| Standard (single-agent) | `docs/research/REPO-RESEARCH-[repo-name]-[date].md` |
+| Parallel (multi-agent) | `temp/AGENT_REPORTS/[repo-name]/RESEARCH_MASTER.md` |
+| Specialist focus reports | `temp/AGENT_REPORTS/[repo-name]/[ROLE]_FOCUS.md` |
+| Council synthesis | `temp/AGENT_REPORTS/[repo-name]/COUNCIL_SYNTHESIS.md` |
 
 ## Related
 
 - `.claude/skills/repo-research.md` - Full skill definition
 - `.claude/templates/repo-research-report-template.md` - Report template
+- `.claude/templates/specialist-focus-template.md` - Specialist focus report template
 - `.claude/agents/sage.md` - Sage persona
+- `.claude/skills/council.md` - Council skill for deliberation
 - `/orchestrate` - For implementing findings

--- a/.claude/skills/repo-research.md
+++ b/.claude/skills/repo-research.md
@@ -18,6 +18,9 @@ description: Research external repositories to extract architecture patterns, im
 - Single repo: `/repo-research <url>`
 - Multi-repo comparison: `/repo-research <url1> <url2> <url3> --compare`
 - Depth control: `--depth=quick|standard|deep`
+- Parallel specialists: `--parallel` (enables multi-agent research)
+- Specialist focus: `--focus=architecture|security|quality` (internal use)
+- Council handoff: `--council` (triggers deliberation after research)
 
 ---
 
@@ -489,6 +492,137 @@ Specify depth: `/repo-research <url> --depth=quick|standard|deep`
 
 ---
 
+## Parallel Specialist Mode
+
+### Overview
+
+Parallel mode enables multiple specialists to simultaneously research different aspects of a repository, providing deeper domain-specific analysis than single-agent research.
+
+### Depth + Parallel Matrix
+
+| Depth | Default Behavior | Parallel Option | Specialist Count |
+|-------|------------------|-----------------|------------------|
+| `quick` | Sage only | Not available | 0 |
+| `standard` | Sage only | `--parallel` adds 1-2 specialists | 0-2 |
+| `deep` | Sage + specialists | `--parallel` (default on) | 3 (full team) |
+
+### Specialist Roles
+
+| Specialist | Focus Flag | Research Emphasis |
+|------------|------------|-------------------|
+| `architect` | `--focus=architecture` | Structure, patterns, data flow, scalability |
+| `security-reviewer` | `--focus=security` | Dependencies, vulnerabilities, auth patterns, data handling |
+| `code-reviewer` | `--focus=quality` | Testing, documentation, maintainability, code standards |
+
+### Enabling Parallel Mode
+
+```bash
+# Standard depth with parallel specialists
+/repo-research <url> --parallel
+
+# Deep research (parallel is default-on)
+/repo-research <url> --depth=deep
+
+# Standard depth with specific specialists only
+/repo-research <url> --parallel --specialists=architect,security-reviewer
+
+# Full workflow with council deliberation
+/repo-research <url> --depth=deep --council
+```
+
+### Focus Flag (Internal Use)
+
+The `--focus` flag is used internally when spawning specialist sub-tasks:
+
+```bash
+# Spawned by master Sage for architecture specialist
+/repo-research <url> --focus=architecture
+
+# Spawned by master Sage for security specialist
+/repo-research <url> --focus=security
+
+# Spawned by master Sage for code quality specialist
+/repo-research <url> --focus=quality
+```
+
+When `--focus` is set, the specialist:
+
+1. Runs all standard research steps
+2. Emphasizes findings relevant to their focus area
+3. Writes to the appropriate specialist report file
+4. Skips master report generation (master Sage handles synthesis)
+
+### Artifact Structure
+
+All parallel research artifacts are stored in `temp/AGENT_REPORTS/[repo-name]/`:
+
+```
+temp/AGENT_REPORTS/[repo-name]/
+├── RESEARCH_MASTER.md          # Sage master report with synthesis
+├── ARCHITECT_FOCUS.md          # Architecture specialist findings
+├── SECURITY_FOCUS.md           # Security specialist findings
+├── QUALITY_FOCUS.md            # Code quality specialist findings
+└── COUNCIL_SYNTHESIS.md        # (Optional) Council deliberation output
+```
+
+**Naming Convention**:
+
+- `[repo-name]` derived from GitHub URL: `owner-repo` format
+- Example: `dbt-labs-dbt-core` for `https://github.com/dbt-labs/dbt-core`
+
+### Parallel Workflow
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  MASTER SAGE                                                    │
+│                                                                 │
+│  1. Parse URL and determine repo-name                           │
+│  2. Create artifact folder: temp/AGENT_REPORTS/[repo-name]/     │
+│  3. Spawn specialists (if --parallel or --depth=deep)           │
+│     ┌─────────────────┬─────────────────┬─────────────────┐    │
+│     │   ARCHITECT     │   SECURITY      │   CODE QUALITY   │    │
+│     │   --focus=arch  │   --focus=sec   │   --focus=qual  │    │
+│     │                 │                 │                 │    │
+│     │   Writes:       │   Writes:       │   Writes:       │    │
+│     │   ARCHITECT_    │   SECURITY_     │   QUALITY_      │    │
+│     │   FOCUS.md      │   FOCUS.md      │   FOCUS.md      │    │
+│     └─────────────────┴─────────────────┴─────────────────┘    │
+│  4. Wait for all specialists to complete                        │
+│  5. Read specialist reports and synthesize                      │
+│  6. Generate RESEARCH_MASTER.md with aggregated findings        │
+│  7. If --council: hand off to council skill                     │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Council Integration
+
+The `--council` flag triggers deliberation after research completes:
+
+```bash
+/repo-research <url> --depth=deep --council
+```
+
+**Council Handoff Protocol**:
+
+1. Master Sage completes research synthesis
+2. Council skill receives paths to all specialist reports:
+   - `temp/AGENT_REPORTS/[repo-name]/RESEARCH_MASTER.md`
+   - `temp/AGENT_REPORTS/[repo-name]/ARCHITECT_FOCUS.md`
+   - `temp/AGENT_REPORTS/[repo-name]/SECURITY_FOCUS.md`
+   - `temp/AGENT_REPORTS/[repo-name]/QUALITY_FOCUS.md`
+3. Council deliberates on diverse perspectives
+4. Council produces `COUNCIL_SYNTHESIS.md` in same artifact folder
+
+**Note**: Council integration requires the council skill to be available. If not available, `--council` flag is ignored with a warning.
+
+### Error Handling
+
+- **Specialist timeout**: If a specialist fails to complete within timeout, master Sage continues with partial results
+- **Specialist error**: Errors are logged, other specialists continue, master report notes incomplete analysis
+- **All specialists fail**: Falls back to standard single-agent research
+
+---
+
 ## Examples
 
 ### Example 1: Single Repo Research (UI Component Library)
@@ -560,7 +694,57 @@ Focus: Spaced repetition implementation and progress tracking
 
 ---
 
-### Example 3: Multi-Repo Comparison (Flashcard Libraries)
+### Example 3: Parallel Specialist Research (dbt Package)
+
+```
+/repo-research https://github.com/dbt-labs/dbt-utils --depth=deep
+```
+
+**Parallel execution** (automatic for deep):
+
+- Master Sage coordinates research
+- Architect specialist focuses on macro patterns, structure
+- Security specialist focuses on dependency chain, SQL injection risks
+- Code reviewer focuses on test coverage, documentation quality
+
+**Artifact structure created**:
+
+```
+temp/AGENT_REPORTS/dbt-labs-dbt-utils/
+├── RESEARCH_MASTER.md      # Synthesized findings
+├── ARCHITECT_FOCUS.md      # Macro architecture, reusability patterns
+├── SECURITY_FOCUS.md       # Dependency audit, SQL safety analysis
+└── QUALITY_FOCUS.md        # Test coverage, docs, maintainability
+```
+
+**Master report synthesis**:
+
+- Convergent findings across specialists
+- Divergent perspectives requiring deliberation
+- Prioritized recommendations by domain
+- Risk matrix aggregated from all specialists
+
+**Handoff to council** (if `--council` used):
+
+```
+sage: → council:
+
+Parallel research complete for dbt-labs-dbt-utils.
+
+**Specialist Reports**:
+- temp/AGENT_REPORTS/dbt-labs-dbt-utils/RESEARCH_MASTER.md
+- temp/AGENT_REPORTS/dbt-labs-dbt-utils/ARCHITECT_FOCUS.md
+- temp/AGENT_REPORTS/dbt-labs-dbt-utils/SECURITY_FOCUS.md
+- temp/AGENT_REPORTS/dbt-labs-dbt-utils/QUALITY_FOCUS.md
+
+**Deliberation Questions**:
+1. Architecture vs. security trade-off on [specific pattern]
+2. Quality concerns about [specific aspect] - severity?
+```
+
+---
+
+### Example 4: Multi-Repo Comparison (Flashcard Libraries)
 
 ```
 /repo-research https://github.com/lib-a/flashcards https://github.com/lib-b/cards https://github.com/lib-c/memorize --compare
@@ -655,12 +839,31 @@ Before completing comparison:
 - [ ] Individual repo reports saved (optional)
 - [ ] Handoff messages prepared
 
+### Parallel Specialist Research
+
+Before completing parallel research:
+
+- [ ] Artifact folder created: `temp/AGENT_REPORTS/[repo-name]/`
+- [ ] All specialists spawned (or subset per `--specialists`)
+- [ ] Specialist reports complete:
+  - [ ] `ARCHITECT_FOCUS.md` (if architect enabled)
+  - [ ] `SECURITY_FOCUS.md` (if security-reviewer enabled)
+  - [ ] `QUALITY_FOCUS.md` (if code-reviewer enabled)
+- [ ] Master report synthesizes specialist findings
+- [ ] Convergent/divergent findings documented
+- [ ] Risk matrix aggregated from all specialists
+- [ ] If `--council`: handoff message prepared with report paths
+- [ ] `RESEARCH_MASTER.md` saved to artifact folder
+
 ---
 
 ## See Also
 
 - `.claude/templates/repo-research-report-template.md` - Report template
+- `.claude/templates/specialist-focus-template.md` - Specialist focus report template
 - `.claude/agents/sage.md` - Sage persona definition
 - `.claude/skills/learning-curation.md` - For post-research pattern extraction
+- `.claude/skills/council.md` - Council skill for deliberation (parallel mode integration)
 - `docs/specs/` - Where PM creates PRDs from findings
 - `docs/specs/` - Where Architect creates TDDs from findings
+- `temp/AGENT_REPORTS/` - Artifact folder for parallel research outputs

--- a/.claude/templates/specialist-focus-template.md
+++ b/.claude/templates/specialist-focus-template.md
@@ -1,0 +1,234 @@
+---
+name: specialist-focus-report
+type: template
+skill: repo-research
+---
+
+# Specialist Focus Report: [Focus Area]
+
+> **Repo**: [Repository Name](https://github.com/owner/repo)
+> **Specialist**: [architect | security-reviewer | code-reviewer]
+> **Focus**: [architecture | security | quality]
+> **Researched**: YYYY-MM-DD
+> **Parent Research**: temp/AGENT_REPORTS/[repo-name]/RESEARCH_MASTER.md
+
+---
+
+## Executive Summary
+
+[2-3 sentence overview of findings from this specialist's perspective]
+
+**Top 3 Findings**:
+
+1. [Most important finding in this focus area]
+2. [Second most important]
+3. [Third most important]
+
+**Risk Level**: Low / Medium / High / Critical
+
+---
+
+## Focus Area Analysis
+
+### Architecture Focus (`--focus=architecture`)
+
+> Use this section if specialist is `architect`
+
+#### Structure Assessment
+
+| Aspect | Rating | Evidence |
+|--------|--------|----------|
+| Modularity | Excellent/Good/Fair/Poor | [Evidence] |
+| Separation of Concerns | Excellent/Good/Fair/Poor | [Evidence] |
+| Scalability Patterns | Excellent/Good/Fair/Poor | [Evidence] |
+| Data Flow Clarity | Excellent/Good/Fair/Poor | [Evidence] |
+
+#### Key Patterns Identified
+
+##### Pattern 1: [Pattern Name]
+
+- **What**: [Description]
+- **Where**: [File/module references]
+- **Applicability**: High/Medium/Low
+- **Adoption complexity**: Low/Medium/High
+
+##### Pattern 2: [Pattern Name]
+
+[Continue as needed...]
+
+#### Data Flow Analysis
+
+[Describe how data moves through the system]
+
+#### Scalability Considerations
+
+[Assessment of how the architecture handles growth]
+
+---
+
+### Security Focus (`--focus=security`)
+
+> Use this section if specialist is `security-reviewer`
+
+#### Security Assessment
+
+| Aspect | Rating | Evidence |
+|--------|--------|----------|
+| Dependency Security | Excellent/Good/Fair/Poor | [Evidence] |
+| Authentication Patterns | Excellent/Good/Fair/Poor | [Evidence] |
+| Data Handling | Excellent/Good/Fair/Poor | [Evidence] |
+| Input Validation | Excellent/Good/Fair/Poor | [Evidence] |
+| Secrets Management | Excellent/Good/Fair/Poor | [Evidence] |
+
+#### Dependency Audit
+
+| Dependency | Version | Known Vulnerabilities | Risk |
+|------------|---------|----------------------|------|
+| [package] | [version] | [CVE or "None"] | Low/Med/High |
+
+#### Vulnerability Findings
+
+##### Finding 1: [Vulnerability Type]
+
+- **Severity**: Critical/High/Medium/Low
+- **Location**: [File/module]
+- **Description**: [What the issue is]
+- **Recommendation**: [How to address]
+
+##### Finding 2: [Vulnerability Type]
+
+[Continue as needed...]
+
+#### Security Patterns (Good Practices)
+
+- [Pattern 1]: [What they do well]
+- [Pattern 2]: [What they do well]
+
+#### Security Concerns
+
+- [Concern 1]: [Description and risk]
+- [Concern 2]: [Description and risk]
+
+---
+
+### Quality Focus (`--focus=quality`)
+
+> Use this section if specialist is `code-reviewer`
+
+#### Quality Assessment
+
+| Aspect | Rating | Evidence |
+|--------|--------|----------|
+| Test Coverage | Excellent/Good/Fair/Poor | [Coverage % if available] |
+| Documentation | Excellent/Good/Fair/Poor | [What docs exist] |
+| Code Standards | Excellent/Good/Fair/Poor | [Linting, formatting] |
+| Maintainability | Excellent/Good/Fair/Poor | [Code complexity, clarity] |
+| Technical Debt | Low/Medium/High | [Evidence of debt] |
+
+#### Testing Analysis
+
+| Test Type | Present | Coverage | Quality |
+|-----------|---------|----------|---------|
+| Unit Tests | Yes/No | X% | Excellent/Good/Fair/Poor |
+| Integration Tests | Yes/No | X% | Excellent/Good/Fair/Poor |
+| E2E Tests | Yes/No | X% | Excellent/Good/Fair/Poor |
+
+#### Documentation Assessment
+
+- **README**: Excellent/Good/Fair/Poor - [Notes]
+- **API Docs**: Excellent/Good/Fair/Poor - [Notes]
+- **Code Comments**: Excellent/Good/Fair/Poor - [Notes]
+- **Examples**: Excellent/Good/Fair/Poor - [Notes]
+
+#### Maintainability Findings
+
+##### Finding 1: [Area]
+
+- **Assessment**: [Description]
+- **Impact**: High/Medium/Low
+- **Recommendation**: [What to do]
+
+##### Finding 2: [Area]
+
+[Continue as needed...]
+
+#### Technical Debt Inventory
+
+| Debt Item | Severity | Estimated Effort | Priority |
+|-----------|----------|------------------|----------|
+| [Item 1] | High/Med/Low | Low/Med/High | P1/P2/P3 |
+
+---
+
+## Risks Identified
+
+| Risk | Likelihood | Impact | Focus Area | Mitigation |
+|------|------------|--------|------------|------------|
+| [Risk 1] | Low/Med/High | Low/Med/High | [arch/sec/qual] | [Mitigation] |
+| [Risk 2] | Low/Med/High | Low/Med/High | [arch/sec/qual] | [Mitigation] |
+
+---
+
+## Recommendations
+
+### For Master Report Synthesis
+
+**Key findings to include**:
+
+1. [Finding 1 - critical for synthesis]
+2. [Finding 2 - important context]
+3. [Finding 3 - notable observation]
+
+**Divergent perspectives** (may conflict with other specialists):
+
+- [Area where this specialist's view may differ]
+- [Reason for potential disagreement]
+
+**Questions for council deliberation** (if `--council`):
+
+- [Question 1 requiring multi-perspective discussion]
+- [Question 2 requiring trade-off analysis]
+
+### Integration Recommendations
+
+| Recommendation | Priority | Complexity | Dependencies |
+|----------------|----------|------------|--------------|
+| [Recommendation 1] | P1/P2/P3 | Low/Med/High | [What it depends on] |
+| [Recommendation 2] | P1/P2/P3 | Low/Med/High | [What it depends on] |
+
+---
+
+## Appendix
+
+### Key File References
+
+| File | Purpose | Notable Finding |
+|------|---------|-----------------|
+| `path/to/file` | [purpose] | [what was found] |
+
+### Evidence Snippets
+
+#### [Snippet Name]
+
+```
+// From: path/to/file
+// Relevant to: [finding]
+
+[code or config snippet]
+```
+
+---
+
+## Handoff
+
+**Status**: Complete
+
+**Next Step**: Master Sage synthesis (RESEARCH_MASTER.md)
+
+**Specialist Notes**:
+
+[Any additional context for the master report author]
+
+---
+
+*Report generated by [specialist role] specialist using repo-research skill with --focus=[focus]*


### PR DESCRIPTION
## Summary

Enhances the `/repo-research` skill with parallel specialist research capabilities:

- **Parallel specialist mode** (`--parallel` flag) for multi-agent research
- **Focus parameter** (`--focus`) for domain-specific research lens
- **Artifact collection** to `temp/AGENT_REPORTS/[repo-name]/`
- **Council integration** (`--council` flag) for deliberation handoff
- **Specialist roles**: architect, security-reviewer, code-reviewer

## Changes

| File | Changes |
|------|---------|
| `.claude/skills/repo-research.md` | +205 lines - parallel mode, depth matrix, specialist roles |
| `.claude/commands/repo-research.md` | +115 lines - new flags, examples, workflow diagram |
| `.claude/templates/specialist-focus-template.md` | New template for specialist reports |

## Depth + Parallel Matrix

| Depth | Default | Parallel Option |
|-------|---------|-----------------|
| quick | Sage only | Not available |
| standard | Sage only | Optional specialists |
| deep | Sage + specialists | Default on |

## Test Plan

- [ ] Single repo research still works
- [ ] `--parallel` spawns focused specialists correctly
- [ ] Artifacts written to `temp/AGENT_REPORTS/[repo-name]/`
- [ ] `--council` flag documented for future integration

## Related

- PRD-017: Repo Research Enhancements
- Depends on: feat/council-skill (for full council integration)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)