### PR TITLE
feat(docs): implement ADR adoption phase 1 (PRD-021)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **ADR Adoption Phase 1**: Formalized architecture decision tracking (PRD-021)
+  - `docs/specs/PRD-021-ADR-ADOPTION.md` - Initiative specification
+  - `docs/reference/ADR_INDEX.md` - Centralized ADR discovery (5 ADRs indexed)
+  - `docs/specs/TDD-TEMPLATE.md` - ADR section with significance criteria, examples
+  - `docs/reference/ROADMAP.md` - Epic E13 (Decision Management) roadmap entry
+  - Goal: Find decision rationale in <2 minutes
+
 ### Planned
 
 - Incremental refresh patterns for large fact tables (v0.7)

--- a/docs/reference/ADR_INDEX.md
+++ b/docs/reference/ADR_INDEX.md
@@ -1,0 +1,134 @@
+---
+audience: [multi-agent, architect, pm]
+priority: high
+size: small
+dependencies: []
+last_updated: 2026-01-31
+status: active
+tags: [reference, decisions, adr, architecture]
+---
+
+# ADR Index
+
+## Purpose
+
+This index provides quick discovery of Architecture Decision Records (ADRs) across the project. ADRs document significant technical decisions with their context, rationale, and consequences.
+
+**Goal**: Find the rationale for any past decision in under 2 minutes.
+
+## How to Use This Index
+
+1. **Finding a decision**: Search or browse the table below
+2. **Understanding a decision**: Follow the Location link to read the full ADR
+3. **Adding a decision**: When writing a TDD, include an ADR section if the decision meets the significance criteria (see TDD-TEMPLATE.md)
+4. **Updating this index**: Add a row when creating a new ADR; update status if superseded
+
+## Quick Stats
+
+| Metric | Count |
+|--------|-------|
+| Total ADRs | 5 |
+| Approved | 5 |
+| Superseded | 0 |
+| Promoted to LEARNINGS.md | 0 |
+
+---
+
+## ADR Registry
+
+| ADR | Title | Status | Location | Approved By | Date | Tags |
+|-----|-------|--------|----------|-------------|------|------|
+| ADR-1 | Database Selection (DuckDB) | Approved | [TDD-001](../specs/TDD-001-DBT-PROJECT-ARCHITECTURE.md#adr-1-database-selection-duckdb) | Architect | 2026-01-28 | infrastructure, database |
+| ADR-2 | Three-Layer Model Architecture | Approved | [TDD-001](../specs/TDD-001-DBT-PROJECT-ARCHITECTURE.md#adr-2-three-layer-model-architecture) | Architect | 2026-01-28 | architecture, dbt |
+| ADR-3 | MCP Integration Strategy | Approved | [TDD-001](../specs/TDD-001-DBT-PROJECT-ARCHITECTURE.md#adr-3-mcp-integration-strategy) | Architect | 2026-01-28 | integration, mcp |
+| ADR-4 | Synthea as Data Source | Approved | [TDD-001](../specs/TDD-001-DBT-PROJECT-ARCHITECTURE.md#adr-4-synthea-as-data-source) | Architect | 2026-01-28 | data-source |
+| ADR-5 | Package Selection | Approved | [TDD-001](../specs/TDD-001-DBT-PROJECT-ARCHITECTURE.md#adr-5-package-selection) | Architect | 2026-01-28 | packages, dbt |
+
+---
+
+## ADR Summary by Category
+
+### Infrastructure & Database
+
+| ADR | Decision | Key Trade-off |
+|-----|----------|---------------|
+| ADR-1 | DuckDB over PostgreSQL | Zero setup vs production similarity |
+
+### Architecture & Patterns
+
+| ADR | Decision | Key Trade-off |
+|-----|----------|---------------|
+| ADR-2 | Staging -> Intermediate -> Marts | More files vs clear separation |
+| ADR-3 | dbt-mcp as primary agent interface | Natural language vs abstraction overhead |
+
+### Data & Integration
+
+| ADR | Decision | Key Trade-off |
+|-----|----------|---------------|
+| ADR-4 | Synthea synthetic healthcare data | Free/realistic vs lacking real-world quality issues |
+| ADR-5 | Incremental package adoption | Minimal complexity vs delayed capabilities |
+
+---
+
+## Governance
+
+### Significance Criteria
+
+A decision warrants an ADR if it meets 2 or more of these criteria:
+
+| Criterion | Description | Example |
+|-----------|-------------|---------|
+| Reversibility Cost | High effort to undo | Database choice, package adoption |
+| Cross-Cutting Impact | Affects multiple features/layers | Naming conventions, error handling |
+| Trade-off Significance | Material trade-offs evaluated | Performance vs simplicity |
+| Constraint Creation | Limits future options | External dependency, API contract |
+| External Dependency | Introduces 3rd party reliance | Package version, service integration |
+
+### Approval Chain
+
+| Impact Level | Criteria | Approver | Example |
+|--------------|----------|----------|---------|
+| High | Irreversible, budget impact, external commitment | Human (Chris) | Cloud service selection |
+| Medium | Cross-cutting, significant trade-offs | Architect + PM | Package adoption |
+| Low | Single-feature, easily reversible | Architect | Implementation approach |
+
+---
+
+## ADR Lifecycle
+
+```text
+Proposed --> Approved --> [Active use] --> Superseded (optional)
+                |                              |
+                +-- Rejected                   +--> New ADR references old
+```
+
+### Status Definitions
+
+| Status | Meaning |
+|--------|---------|
+| Proposed | Under discussion, not yet approved |
+| Approved | Decision made and active |
+| Superseded | Replaced by a newer ADR (link to replacement) |
+| Deprecated | No longer relevant but kept for history |
+
+---
+
+## Future: Pattern Promotion
+
+When an ADR pattern is validated in 2+ implementations, it becomes a candidate for promotion to LEARNINGS.md. The Sage agent reviews completed features for promotion opportunities.
+
+| ADR | Implementations | Promoted? |
+|-----|-----------------|-----------|
+| ADR-2 (Three-Layer) | All 28 models | Candidate |
+
+---
+
+## Related
+
+- [TDD-TEMPLATE.md](../specs/TDD-TEMPLATE.md) - ADR format and examples
+- [LEARNINGS.md](./LEARNINGS.md) - Promoted patterns
+- [PRD-021](../specs/PRD-021-ADR-ADOPTION.md) - ADR Adoption Initiative
+
+---
+
+*Created: 2026-01-31 | Maintainer: Architect*

--- a/docs/reference/ROADMAP.md
+++ b/docs/reference/ROADMAP.md
@@ -163,6 +163,46 @@ Build a dbt analytics project while learning data transformation best practices 
 
 **Related Issues**: #35, #36, #37
 
+### Epic E13: Decision Management (ADR Adoption)
+
+**Theme**: Formalized Decision Tracking
+
+**Status**: Phase 1 Complete (2026-01-31)
+
+**Problem**: Technical decisions are made but not systematically findable. We spend time re-discovering rationale and re-debating settled questions.
+
+**Goal**: Reduce decision archaeology time by 80% (decisions findable in <2 minutes).
+
+**Phases**:
+
+| Phase | Version | Status | Deliverables |
+|-------|---------|--------|--------------|
+| Phase 1: Foundation | v0.7 | Complete | TDD-TEMPLATE ADR section, ADR_INDEX.md with 5 ADRs |
+| Phase 2: Integration | v0.8 | Planned | ADR-to-LEARNINGS promotion, Sage integration, historical backfill |
+| Phase 3: Maturity | v0.9+ | Planned | Metrics, FOR_CHRIS doc, template refinement |
+
+**Phase 1 Deliverables** (Complete):
+
+- [x] PRD-021: ADR Adoption Initiative
+- [x] TDD-TEMPLATE.md updated with ADR section and examples
+- [x] ADR_INDEX.md created with TDD-001 entries (ADR-1 through ADR-5)
+- [x] Significance criteria and approval chain documented
+
+**Phase 2 Deliverables** (Planned):
+
+- [ ] ADR-to-LEARNINGS promotion workflow
+- [ ] Sage persona update for promotion reviews
+- [ ] Session resume checklist with ADR review
+- [ ] 3-5 historical ADRs backfilled from v0.3-v0.6
+
+**Phase 3 Deliverables** (Quarterly):
+
+- [ ] ADR adoption metrics (count, promotion rate)
+- [ ] FOR_CHRIS: Understanding Decision-Making Patterns
+- [ ] Template refinements based on usage
+
+**Related**: [PRD-021](../specs/PRD-021-ADR-ADOPTION.md), [ADR_INDEX](./ADR_INDEX.md)
+
 ---
 
 ## Future Considerations

--- a/docs/specs/PRD-021-ADR-ADOPTION.md
+++ b/docs/specs/PRD-021-ADR-ADOPTION.md
@@ -1,0 +1,268 @@
+# PRD-021: ADR Adoption Initiative
+
+## Overview
+
+**Author**: Product Manager (Claude Code Agent System)
+**Status**: Draft
+**Created**: 2026-01-31
+**Updated**: 2026-01-31
+
+### Problem Statement
+
+Technical decisions in this project are made but not systematically recorded. We have evidence of good decisions (TDD-001 contains embedded ADRs 1-5) but also evidence of decisions lost to conversation history:
+
+1. **Decision Archaeology**: When revisiting past work, we spend time re-discovering why choices were made (e.g., "Why DuckDB over PostgreSQL?" is answered in TDD-001, but "Why metric marts over semantic layer?" requires finding old conversations)
+
+2. **Repeated Debates**: Without recorded decisions, the same trade-offs get re-evaluated. The v0.5.5 semantic layer decision was re-debated because the original rationale was not formally captured.
+
+3. **Onboarding Friction**: New agents (or returning agents with cleared context) lack access to decision history, leading to proposals that conflict with prior decisions.
+
+4. **Pattern Promotion Gap**: Proven decisions should flow to LEARNINGS.md, but there is no systematic trigger. The "Context Window Discipline" pattern made it to LEARNINGS.md; many others did not.
+
+**Validation**: The Architect consultation confirmed that we already practice ADR-like documentation in TDD-001, suggesting the overhead is acceptable when integrated naturally rather than imposed as ceremony.
+
+### Goal
+
+Formalize decision tracking to:
+
+- Reduce decision archaeology time by 80% (decisions findable in <2 minutes)
+- Eliminate repeated debates on settled questions
+- Create clear pathway from "decision made" to "pattern proven"
+- Maintain lightweight overhead that fits existing PRD/TDD workflow
+
+### Reference
+
+- Architect Consultation: Embedded ADRs + centralized index recommended
+- Prior Art: TDD-001 ADRs 1-5 (database selection, architecture, MCP, data source, packages)
+- Industry Pattern: Lightweight ADRs (Nygard format), decision logs, Y-statements
+
+## User Stories
+
+As a **returning agent** (or Claude session resuming work), I want to find the rationale for past decisions so that I can work within existing constraints without re-debating settled questions.
+
+As an **Architect**, I want a lightweight way to record significant decisions so that the overhead does not discourage documentation but the decisions are findable.
+
+As a **PM**, I want to know what decisions require my input so that I can prioritize stakeholder alignment on consequential choices.
+
+As a **Sage (knowledge curator)**, I want a clear signal for when decisions should become LEARNINGS.md patterns so that proven approaches are systematically captured.
+
+As a **human learner (Chris)**, I want to understand why the project evolved as it did so that I can apply these decision-making patterns to future projects.
+
+As a **future maintainer**, I want to understand historical constraints so that I can safely change decisions when constraints evolve.
+
+## Requirements
+
+### Functional Requirements
+
+#### FR-1: Embedded ADR Format in TDDs
+
+Continue the pattern established in TDD-001: include ADRs inline within TDD documents.
+
+**ADR Template**:
+
+```markdown
+### ADR-N: [Decision Title]
+
+**Status**: Proposed | Approved | Superseded by ADR-M
+
+**Context**: What situation requires a decision?
+
+**Decision**: What is the choice made?
+
+**Rationale**: Why this choice over alternatives? (Table format preferred)
+
+**Consequences**:
+- **Positive**: [benefits]
+- **Negative**: [drawbacks]
+- **Mitigation**: [how we address drawbacks]
+
+**Approval**: [Architect | PM + Architect | Human]
+```
+
+**Acceptance Criteria**:
+
+- [ ] ADR template documented in TDD-TEMPLATE.md
+- [ ] Existing TDD-001 ADRs serve as examples
+- [ ] Format supports optional "Superseded by" for decision evolution
+
+#### FR-2: Centralized ADR Index
+
+Create `docs/reference/ADR_INDEX.md` as a discovery mechanism.
+
+**Index Structure**:
+
+```markdown
+# ADR Index
+
+| ADR | Title | Status | Location | Approved By | Date |
+|-----|-------|--------|----------|-------------|------|
+| ADR-1 | Database Selection (DuckDB) | Approved | TDD-001 | Architect | 2026-01-28 |
+| ADR-2 | Three-Layer Model Architecture | Approved | TDD-001 | Architect | 2026-01-28 |
+```
+
+**Acceptance Criteria**:
+
+- [ ] ADR_INDEX.md created with existing TDD-001 ADRs
+- [ ] Index includes location link for quick navigation
+- [ ] Format supports filtering by status, approver, topic
+
+#### FR-3: Decision Significance Criteria
+
+Define when a decision warrants an ADR (avoid over-documenting).
+
+**Significance Test** (2+ criteria = ADR warranted):
+
+| Criterion | Description | Example |
+|-----------|-------------|---------|
+| Reversibility Cost | High effort to undo | Database choice, package adoption |
+| Cross-Cutting Impact | Affects multiple features/layers | Naming conventions, error handling pattern |
+| Trade-off Significance | Material trade-offs were evaluated | Performance vs. simplicity, vendor choice |
+| Constraint Creation | Limits future options | External dependency, API contract |
+| External Dependency | Introduces 3rd party reliance | Package version, service integration |
+
+**Acceptance Criteria**:
+
+- [ ] Significance criteria documented in TDD-TEMPLATE.md
+- [ ] Architect uses criteria during TDD creation
+- [ ] PM can challenge ADR necessity based on criteria
+
+#### FR-4: Approval Chain Definition
+
+Establish who approves decisions based on impact level.
+
+| Impact Level | Criteria | Approver | Example |
+|--------------|----------|----------|---------|
+| High | Irreversible, budget impact, external commitment | Human (Chris) | Cloud service selection, major refactor |
+| Medium | Cross-cutting, significant trade-offs | Architect + PM | Package adoption, architecture pattern |
+| Low | Single-feature, easily reversible | Architect | Implementation approach, tool choice |
+
+**Acceptance Criteria**:
+
+- [ ] Impact levels documented with examples
+- [ ] ADR template includes "Approval" field
+- [ ] High-impact decisions surface for human review
+
+#### FR-5: ADR-to-LEARNINGS Pipeline
+
+Create explicit pathway for proven decisions to become patterns.
+
+**Promotion Trigger**: ADR pattern validated in 2+ real implementations.
+
+**Process**:
+
+1. Sage reviews completed features for ADR patterns
+2. If pattern applied 2+ times successfully, promote to LEARNINGS.md
+3. LEARNINGS.md entry references originating ADRs
+4. ADR index notes "Promoted to LEARNINGS.md"
+
+**Acceptance Criteria**:
+
+- [ ] Promotion criteria documented
+- [ ] LEARNINGS.md entry template includes "Validated by ADRs" reference
+- [ ] Review trigger added to session end workflow
+
+### Non-Functional Requirements
+
+1. **NFR-1**: ADR creation should add <5 minutes to TDD authoring
+2. **NFR-2**: ADR lookup should take <2 minutes (index enables discovery)
+3. **NFR-3**: Format must be human-readable (not just machine-parseable)
+4. **NFR-4**: Works without external tools (markdown only)
+5. **NFR-5**: Backward compatible with existing TDD-001 format
+
+## Scope
+
+### In Scope
+
+**Phase 1 (v0.7 - Immediate)**:
+
+- ADR template in TDD-TEMPLATE.md
+- ADR_INDEX.md with TDD-001 entries
+- Significance criteria documentation
+- Approval chain documentation
+
+**Phase 2 (v0.8 - Next Sprint)**:
+
+- ADR-to-LEARNINGS promotion process
+- Sage integration for pattern promotion
+- Retrospective review of v0.3-v0.6 for missing ADRs
+
+**Phase 3 (v0.9+ - Quarterly)**:
+
+- ADR usage metrics (count, promotion rate)
+- Template refinement based on usage
+- FOR_CHRIS educational document on decision-making
+
+### Out of Scope
+
+- Standalone ADR directory (embedded in TDDs instead)
+- ADR tooling/automation (stay markdown-native)
+- Migrating all historical decisions (only significant ones worth archaeology)
+- External ADR hosting or publishing
+
+## Dependencies
+
+- TDD-TEMPLATE.md must be updated (Architect)
+- LEARNINGS.md must exist and be maintained (Sage)
+- Session summary workflow (for promotion trigger)
+
+## Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Decision discovery time | <2 minutes | Time to find rationale for past decision |
+| ADR adoption rate | 100% of new TDDs with significant decisions | ADR_INDEX.md entries |
+| Pattern promotion rate | 1+ patterns per quarter | LEARNINGS.md entries citing ADRs |
+| Re-debate reduction | 0 repeated debates on indexed decisions | Qualitative (conversation review) |
+
+## Open Questions
+
+1. **Should we backfill ADRs for v0.3-v0.6 decisions?**
+   - Recommendation: Only if we are actively re-debating them. Backfill on demand, not proactively.
+
+2. **How do we handle ADRs that span multiple TDDs?**
+   - Recommendation: ADR lives in the originating TDD; other TDDs reference it.
+
+3. **What happens when a decision is superseded?**
+   - Recommendation: Original ADR status changes to "Superseded by ADR-M"; new ADR explains why.
+
+4. **Should standalone decisions (not tied to a TDD) get ADRs?**
+   - Recommendation: Create an "ADR-only" section in ADR_INDEX.md for decisions without TDD context.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| ADR location | Embedded in TDDs | Reduces file proliferation; keeps decision near technical context |
+| Index format | Markdown table | Simple, no tooling required, sortable in editors |
+| Promotion trigger | 2+ implementations | Prevents premature pattern extraction |
+| Approval chain | 3 tiers | Balances rigor with velocity |
+
+## Alignment Check
+
+**Does this align with team culture?**
+
+Yes. TDD-001 demonstrates the team already creates ADR-like content naturally. This initiative formalizes discovery (index) without adding ceremony to creation.
+
+**Is the benefit worth the overhead?**
+
+Yes, if we:
+
+- Keep ADRs embedded (no separate files to manage)
+- Only require ADRs for significant decisions (2+ criteria)
+- Make the index a living document, not a bureaucratic gate
+
+**What could go wrong?**
+
+| Risk | Mitigation |
+|------|------------|
+| ADR ceremony slows TDD creation | Significance criteria prevents over-documentation |
+| Index becomes stale | Architect adds to index as part of TDD completion |
+| ADRs not consulted | Session resume checklist includes "review relevant ADRs" |
+| Pattern promotion forgotten | Sage reviews at session end |
+
+## Related
+
+- **TDD-001**: Contains ADRs 1-5 as prior art
+- **LEARNINGS.md**: Destination for proven patterns
+- **TDD-TEMPLATE.md**: Will be updated with ADR section
+- **PRD-016**: Agent context management (related workflow)

--- a/docs/specs/TDD-TEMPLATE.md
+++ b/docs/specs/TDD-TEMPLATE.md
@@ -12,6 +12,121 @@
 
 [Brief technical summary of the implementation approach]
 
+## Architecture Decisions
+
+> **When to include ADRs**: Include an ADR for decisions that meet 2+ of the significance criteria below. Not every TDD needs ADRs - only include them for consequential decisions.
+
+### Significance Criteria
+
+Before writing an ADR, verify the decision meets at least 2 of these criteria:
+
+| Criterion | Description | Example |
+|-----------|-------------|---------|
+| Reversibility Cost | High effort to undo | Database choice, package adoption |
+| Cross-Cutting Impact | Affects multiple features/layers | Naming conventions, error handling pattern |
+| Trade-off Significance | Material trade-offs were evaluated | Performance vs. simplicity, vendor choice |
+| Constraint Creation | Limits future options | External dependency, API contract |
+| External Dependency | Introduces 3rd party reliance | Package version, service integration |
+
+**Quick test**: If the decision only affects this feature and is easily changeable later, it probably does not need an ADR.
+
+### ADR-N: [Decision Title]
+
+**Status**: Proposed | Approved | Superseded by ADR-M
+
+**Context**: What situation requires a decision? What constraints exist?
+
+**Decision**: What is the choice made?
+
+**Rationale**:
+
+| Criterion | Option A | Option B | Option C |
+|-----------|----------|----------|----------|
+| [Criterion 1] | [Value] | [Value] | [Value] |
+| [Criterion 2] | [Value] | [Value] | [Value] |
+
+**Consequences**:
+
+- **Positive**: [Benefits of this decision]
+- **Negative**: [Drawbacks or limitations]
+- **Mitigation**: [How we address the negatives]
+
+**Approval**: [Architect | PM + Architect | Human]
+
+> **After creating an ADR**: Add an entry to [ADR_INDEX.md](../reference/ADR_INDEX.md)
+
+---
+
+### ADR Examples from TDD-001
+
+<details>
+<summary>Example: ADR-1 Database Selection (Low complexity)</summary>
+
+**ADR-1: Database Selection (DuckDB)**
+
+**Status**: Approved
+
+**Context**: The project needs a database for analytics development that supports zero infrastructure overhead, fast analytical queries, and native CSV import.
+
+**Decision**: Use DuckDB as the primary database.
+
+**Rationale**:
+
+| Criterion | DuckDB | PostgreSQL | SQLite |
+|-----------|--------|------------|--------|
+| Setup Complexity | None (embedded) | Docker/Install | None |
+| Analytical Performance | Excellent (columnar) | Good | Poor |
+| CSV Import | Native `read_csv_auto()` | COPY command | Extension |
+
+**Consequences**:
+
+- **Positive**: Immediate productivity, no DevOps overhead
+- **Negative**: SQL dialect differences from production databases
+- **Mitigation**: Document DuckDB-specific syntax; plan PostgreSQL phase later
+
+**Approval**: Architect
+
+</details>
+
+<details>
+<summary>Example: ADR-2 Architecture Pattern (Cross-cutting)</summary>
+
+**ADR-2: Three-Layer Model Architecture**
+
+**Status**: Approved
+
+**Context**: dbt projects require a layered architecture for maintainability and clarity.
+
+**Decision**: Adopt staging -> intermediate -> marts architecture (Kimball-inspired).
+
+**Rationale**:
+
+| Layer | Prefix | Materialization | Purpose |
+|-------|--------|-----------------|---------|
+| Staging | `stg_` | View | 1:1 with source, clean and rename |
+| Intermediate | `int_` | View | Business logic, joins, enrichment |
+| Marts | `dim_`/`fct_` | Table | Analytics-ready, optimized for queries |
+
+**Consequences**:
+
+- **Positive**: Clear separation of concerns, industry-standard pattern
+- **Negative**: More files to maintain
+- **Mitigation**: Use dbt documentation and lineage graphs
+
+**Approval**: Architect
+
+</details>
+
+### Approval Chain Reference
+
+| Impact Level | Criteria | Approver | Example |
+|--------------|----------|----------|---------|
+| High | Irreversible, budget impact, external commitment | Human (Chris) | Cloud service selection, major refactor |
+| Medium | Cross-cutting, significant trade-offs | Architect + PM | Package adoption, architecture pattern |
+| Low | Single-feature, easily reversible | Architect | Implementation approach, tool choice |
+
+---
+
 ## Architecture
 
 ### High-Level Design
@@ -119,4 +234,5 @@ Function/method signatures and contracts
 
 - **PRD**: [Link to PRD]
 - **Issue**: [GitHub issue link]
+- **ADR Index**: [docs/reference/ADR_INDEX.md](../reference/ADR_INDEX.md)
 - **Diagram**: [Architecture diagram file]


### PR DESCRIPTION
## Summary

Implements Phase 1 of the ADR (Architecture Decision Record) Adoption Initiative as specified in PRD-021.

**Problem**: Technical decisions are made but not systematically recorded. We spend time re-discovering rationale and re-debating settled questions.

**Solution**: Formalize decision tracking with embedded ADRs in TDDs and a centralized index for discovery.

Closes #105

## Deliverables

| Deliverable | Location | Description |
|-------------|----------|-------------|
| PRD-021 | `docs/specs/PRD-021-ADR-ADOPTION.md` | Full initiative specification |
| ADR Index | `docs/reference/ADR_INDEX.md` | Centralized discovery (5 ADRs from TDD-001) |
| TDD Template Update | `docs/specs/TDD-TEMPLATE.md` | ADR section with criteria and examples |
| Roadmap Update | `docs/reference/ROADMAP.md` | Epic E13: Decision Management |

## Success Criteria

- [x] PRD-021 in `docs/specs/`
- [x] TDD-TEMPLATE has ADR section with significance criteria
- [x] ADR_INDEX lists 5 existing ADRs from TDD-001
- [x] Roadmap updated with E13 epic (3 phases)
- [x] All markdown linting passes
- [x] All internal links validated
- [x] CHANGELOG updated

## Phase 2 Scope (v0.8 - deferred)

- ADR-to-LEARNINGS promotion workflow
- Sage persona integration for promotion reviews
- Historical ADR backfill (3-5 from v0.3-v0.6)

## Test Plan

- [x] Verified all TDD-001 anchor links resolve correctly
- [x] Validated ADR template with sample ADR (TEST_SAMPLE_ADR.md)
- [x] Confirmed markdown linting passes (0 errors)
- [x] Code review completed (CODE_REVIEW.md in agent reports)

---

Generated with [Claude Code](https://claude.com/claude-code)