### PR TITLE
fix(ci): add missing dbt deps step to dbt-test workflow

### DIFF
--- a/.github/workflows/dbt-test.yml
+++ b/.github/workflows/dbt-test.yml
@@ -47,6 +47,9 @@ jobs:
                 threads: 4
           EOF
 
+      - name: Install dbt packages
+        run: uv run dbt deps
+
       - name: Load source data
         run: uv run dbt run-operation load_synthea_sources
 


### PR DESCRIPTION
## Summary

Fixes the dbt-test CI workflow by adding the missing `dbt deps` step.

## Problem

The workflow was failing with:
```
Compilation Error: dbt found 4 package(s) specified in packages.yml, 
but only 0 package(s) installed in dbt_packages. Run "dbt deps" to 
install package dependencies.
```

## Solution

Added a new step "Install dbt packages" that runs `uv run dbt deps` after profile setup and before any dbt operations.

## Changes

- Add `dbt deps` step to `.github/workflows/dbt-test.yml`
- Positioned after "Setup dbt profile" and before "Load source data"

## Impact

This fix unblocks PR #103 (Workflow Hub v0.7) which is currently failing CI checks due to this missing step.

## Test Plan

- [x] Local verification: workflow structure is correct
- [ ] CI verification: wait for GitHub Actions to run

Closes #103 (indirectly - unblocks it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)