### PR TITLE
feat(supervisor): add capability readiness assessment

### DIFF
--- a/.claude/agents/AGENTS.md
+++ b/.claude/agents/AGENTS.md
@@ -22,6 +22,7 @@
 | Typo fix | **Manual** | Direct | Too simple for agent overhead |
 | Small CSS tweak | **Manual** | Direct | Quick, obvious change |
 | Exploratory research | **Agent** | `Explore` | Thorough codebase analysis |
+| Readiness assessment | **Skill** | `/readiness-check` | Assess gaps before new work |
 | dbt model design | **Agent** | `data-modeler` | Dimensional modeling expertise |
 | dbt implementation | **Agent** | `dbt-developer` | SQL/Jinja best practices |
 | dbt testing | **Agent** | `dbt-tester` | Data quality validation |
@@ -1156,10 +1157,11 @@ Healthcare Analyst → Data Modeler → dbt Developer → dbt Tester → Code Re
   Domain Context      Design SQL    Implement      Add tests      Review        Document
 ```
 
-**Commands** (see `.claude/commands/dbt-*.md` for details):
+**Commands** (see `.claude/commands/` for details):
 
-| Command | Purpose | Agent |
-|---------|---------|-------|
+| Command | Purpose | Agent/Skill |
+|---------|---------|-------------|
+| `/readiness-check` | Assess capability gaps before work | Supervisor + Skill |
 | `/dbt-model` | Create new models | Data Modeler |
 | `/dbt-test` | Add/run tests | dbt Tester |
 | `/dbt-run` | Execute dbt commands | dbt Developer |

--- a/.claude/agents/sage.md
+++ b/.claude/agents/sage.md
@@ -300,6 +300,80 @@ sage: check if ADR-3 is ready for promotion
 sage: what ADRs have 2+ implementations?
 ```
 
+### Workflow I: Gap Resolution Research
+
+```
+Trigger: Readiness check referral from Supervisor (RESEARCH_NEEDED status)
+Input: temp/READINESS_CHECK_[feature].md, gap descriptions
+
+Process:
+1. Read readiness check output for identified gaps
+2. For each gap, determine research approach:
+   - Missing patterns → Search external repos, extract to LEARNINGS.md
+   - Unknown tools → Research documentation, create skill if warranted
+   - No prior experience → Find reference implementations, document patterns
+3. Coordinate with /repo-research for external sources:
+   - sage: → /repo-research [url] for deep external analysis
+   - Sage focuses on pattern extraction, repo-research on raw data
+4. Update LEARNINGS.md with new patterns (if proven or well-documented externally)
+5. Create skill file if workflow is actionable
+6. Report resolution status to Supervisor
+7. Recommend re-running /readiness-check
+
+Output: Updated LEARNINGS.md, optional skill files, resolution report
+```
+
+**Gap Resolution Decision Tree**:
+
+```
+[Gap Identified]
+    │
+    ├─ Is gap about missing patterns/knowledge?
+    │   ├─ Yes → Search for external references
+    │   │   ├─ Found documented pattern → Add to LEARNINGS.md
+    │   │   ├─ Found repo with examples → /repo-research [url]
+    │   │   └─ No external source → Note as "novel work, proceed with caution"
+    │   └─ No → Continue
+    │
+    ├─ Is gap about missing tools?
+    │   ├─ Yes → Can tool be installed?
+    │   │   ├─ Yes (package) → Recommend: uv add [package]
+    │   │   ├─ Yes (MCP) → Document configuration steps
+    │   │   └─ No → Mark as BLOCKING
+    │   └─ No → Continue
+    │
+    └─ Is gap about missing experience?
+        ├─ Yes → Find reference implementations
+        │   ├─ Internal prior art → Document pattern
+        │   └─ External examples → /repo-research
+        └─ No → Gap resolution complete
+```
+
+**Example Invocations**:
+
+```text
+sage: resolve gaps for tuva-integration
+sage: research gaps from temp/READINESS_CHECK_customer-analytics.md
+sage: what patterns exist for dbt_expectations testing?
+```
+
+**Handoff to Supervisor**:
+
+```
+sage: → super:
+
+Gap resolution complete for [feature].
+
+**Gaps Resolved**:
+1. [Gap] → Added pattern to LEARNINGS.md
+2. [Gap] → Created skill file .claude/skills/learned-pattern-X.md
+
+**Gaps Remaining**:
+- [Gap if any] → Reason unresolved
+
+**Recommendation**: Re-run /readiness-check [request]
+```
+
 ### Sage Trigger Conditions (Updated)
 
 Sage extracts learnings when:
@@ -311,6 +385,7 @@ Sage extracts learnings when:
 | Version tag | Deployment milestone created | Auto-notify |
 | Failure threshold | ≥10 test failures in session | Auto |
 | User rejection | Output rejected by user | Auto |
+| Readiness gap referral | Supervisor refers RESEARCH_NEEDED gaps | Semi-auto |
 
 **NOT triggered automatically on every PR merge** - this prevents noise and ensures Sage focuses on meaningful learnings.
 

--- a/.claude/agents/supervisor.md
+++ b/.claude/agents/supervisor.md
@@ -412,6 +412,165 @@ When thresholds are met, Sage is automatically invoked.
 
 ---
 
+## Readiness Check Integration
+
+The Supervisor runs `/readiness-check` at new request intake to assess capability gaps before committing to work.
+
+### When to Invoke
+
+**Automatic**: After scope clarification for any non-trivial request, before `/orchestrate`.
+
+**Skip for**:
+
+- Simple tasks (typo fixes, minor edits)
+- Tasks resuming from previous session (already assessed)
+- Pure documentation or research tasks
+
+### Readiness Check Flow
+
+```
+[After Scope Clarification]
+    │
+    ├─ Run /readiness-check [request]
+    │
+    ├─ Wait for assessment (checks knowledge, tools, experience)
+    │
+    ├─ Receive status and score:
+    │
+    ├─ READY (≥80)
+    │   └─ Proceed to /orchestrate [feature] [flags]
+    │
+    ├─ ADVISORY (60-79)
+    │   └─ Note gaps in WORKFLOW_STATE.md
+    │   └─ Inform user of gaps
+    │   └─ Proceed to /orchestrate with caution
+    │
+    ├─ RESEARCH_NEEDED (40-59)
+    │   └─ Report gaps to user
+    │   └─ Offer: /repo-research [url] or sage: resolve gaps
+    │   └─ Wait for research completion
+    │   └─ Re-run /readiness-check
+    │
+    └─ BLOCKED (<40)
+        └─ Report blockers to user
+        └─ List required actions (tool install, config, clarification)
+        └─ Wait for user decision
+        └─ Do NOT proceed to /orchestrate
+```
+
+### Updated New Request Flow
+
+The original New Request flow is augmented with readiness check:
+
+```
+[New Request Received]
+    │
+    ├─ Is this on the roadmap?
+    │   ├─ Yes → Check for existing PRD
+    │   └─ No → Ad-hoc request
+    │
+    ├─ Clarify: What phases should be skipped?
+    │   ├─ Full workflow → No flags
+    │   ├─ Minor fix → --skip-prd or --skip-tdd
+    │   └─ Quick fix → --dev-only
+    │
+    ├─ **NEW: Run /readiness-check [request]**
+    │   ├─ READY → Continue
+    │   ├─ ADVISORY → Note gaps, continue
+    │   ├─ RESEARCH_NEEDED → Pause for research
+    │   └─ BLOCKED → Stop, report blockers
+    │
+    ├─ Which track? (new or existing)
+    │   ├─ New → Create track in WORKFLOW_STATE.md
+    │   └─ Existing → Update track status
+    │
+    └─ Delegate to /orchestrate with appropriate flags
+```
+
+### Threshold Decision Handling
+
+| Score | Status | Supervisor Action |
+|-------|--------|-------------------|
+| 80-100 | READY | Proceed immediately to `/orchestrate` |
+| 60-79 | ADVISORY | Note gaps in WORKFLOW_STATE.md, inform user, proceed |
+| 40-59 | RESEARCH_NEEDED | Pause workflow, offer `/repo-research` or `sage: resolve gaps` |
+| 0-39 | BLOCKED | Stop workflow, report blockers, await user decision |
+
+### WORKFLOW_STATE.md Recording
+
+When readiness check completes, record the result:
+
+```yaml
+### Track: feat/example-feature (ACTIVE)
+- **Phase**: PLANNING
+- **Readiness Check**: 2026-01-31T10:00:00Z
+- **Readiness Score**: 75/100 (ADVISORY)
+- **Readiness Status**: ADVISORY
+- **Gaps Noted**:
+  - [ ] Missing dbt_expectations patterns (ADVISORY)
+  - [ ] Package not installed (ADVISORY)
+```
+
+### Gap Resolution Coordination
+
+For RESEARCH_NEEDED results, coordinate with Sage:
+
+```
+super: → sage:
+
+Readiness check returned RESEARCH_NEEDED (score: 52/100).
+
+**Gaps requiring research**:
+1. No Tuva patterns in LEARNINGS.md
+2. Healthcare connector patterns unknown
+
+**Request**: Research gaps and extract patterns.
+
+**Readiness check output**: temp/READINESS_CHECK_tuva-integration.md
+
+sage: resolve gaps for tuva-integration
+```
+
+After Sage completes gap resolution:
+
+1. Re-run `/readiness-check [request]`
+2. If now READY or ADVISORY, proceed
+3. If still RESEARCH_NEEDED, assess if additional research needed
+4. If still BLOCKED, escalate to user
+
+### Example Readiness Check Invocations
+
+```text
+# Standard new feature request
+super: I want to add customer analytics
+→ [clarify scope]
+→ /readiness-check Add customer analytics mart with LTV calculations
+→ READY (85/100)
+→ /orchestrate customer-analytics
+
+# Complex integration request
+super: Let's integrate Tuva health data
+→ [clarify scope]
+→ /readiness-check Integrate Tuva clinical data connector
+→ RESEARCH_NEEDED (48/100)
+→ Offer: /repo-research https://github.com/tuva-health/tuva
+→ [user accepts]
+→ [research completes]
+→ /readiness-check Integrate Tuva clinical data connector
+→ ADVISORY (72/100)
+→ /orchestrate tuva-integration
+
+# Blocked request
+super: Deploy to Snowflake production
+→ [clarify scope]
+→ /readiness-check Add Snowflake production deployment
+→ BLOCKED (32/100)
+→ Report: Missing dbt-snowflake adapter, no credentials configured
+→ Await user decision
+```
+
+---
+
 ## PR-Centric Review Orchestration (NEW)
 
 The Supervisor manages multi-agent reviews through GitHub PRs, ensuring feedback is captured in git history.

--- a/.claude/commands/readiness-check.md
+++ b/.claude/commands/readiness-check.md
@@ -1,0 +1,133 @@
+# Readiness Check Command
+
+Assess capability gaps (knowledge, tools, experience) before committing to work.
+
+## Usage
+
+```
+/readiness-check [task description]
+```
+
+## Examples
+
+```
+/readiness-check Add dbt_expectations tests to staging models
+/readiness-check Implement customer LTV analytics mart
+/readiness-check Integrate Tuva clinical data connector
+/readiness-check Add Snowflake production deployment
+```
+
+## Workflow
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  READINESS CHECK                                            │
+│                                                             │
+│  1. Scope Extraction                                        │
+│     - Parse request for technical requirements              │
+│     - Identify domain and complexity                        │
+│     - Extract search keywords                               │
+│                                                             │
+│  2. Knowledge Assessment (40%)                              │
+│     - Search LEARNINGS.md for patterns                      │
+│     - Check skills/ for workflows                           │
+│     - Find prior implementations                            │
+│                                                             │
+│  3. Tools Assessment (30%)                                  │
+│     - Verify packages in pyproject.toml                     │
+│     - Check MCP server availability                         │
+│     - Validate environment configuration                    │
+│                                                             │
+│  4. Experience Assessment (30%)                             │
+│     - Search CHANGELOG for similar work                     │
+│     - Count prior implementations                           │
+│     - Assess novelty level                                  │
+│                                                             │
+│  5. Gap Analysis                                            │
+│     - Classify gaps as BLOCKING vs ADVISORY                 │
+│     - Calculate composite score                             │
+│                                                             │
+│  6. Decision                                                │
+│     - READY (≥80): Proceed to /orchestrate                  │
+│     - ADVISORY (60-79): Proceed with noted gaps             │
+│     - RESEARCH_NEEDED (40-59): Research first               │
+│     - BLOCKED (<40): Resolve blockers first                 │
+├─────────────────────────────────────────────────────────────┤
+│  OUTPUT: temp/READINESS_CHECK_[feature].md                  │
+├─────────────────────────────────────────────────────────────┤
+│  INTEGRATION                                                │
+│                                                             │
+│  Supervisor auto-invokes after scope clarification          │
+│  Sage provides gap resolution research if needed            │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Score Thresholds
+
+| Score | Status | Next Action |
+|-------|--------|-------------|
+| 80-100 | READY | Proceed to `/orchestrate` |
+| 60-79 | ADVISORY | Proceed with gaps noted |
+| 40-59 | RESEARCH_NEEDED | Run `/repo-research` or `sage: research` |
+| 0-39 | BLOCKED | Resolve blockers; await user decision |
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--dimension=knowledge\|tools\|experience` | Check single dimension only |
+| `--verbose` | Show all search results |
+| `--skip-output` | Don't write artifact file |
+
+## Output
+
+**Report Location**: `temp/READINESS_CHECK_[feature].md`
+
+**Report Sections**:
+
+1. Scope Summary
+2. Knowledge Assessment (patterns, skills, prior art)
+3. Tools Assessment (packages, MCP, environment)
+4. Experience Assessment (CHANGELOG, prior work)
+5. Gap Analysis (BLOCKING vs ADVISORY)
+6. Recommendations and Next Steps
+
+## Supervisor Integration
+
+The Supervisor automatically runs `/readiness-check` at new request intake:
+
+```
+[New Request Received]
+    │
+    ├─ Clarify scope with user
+    │
+    ├─ Run /readiness-check [request]
+    │
+    ├─ READY → /orchestrate [feature]
+    ├─ ADVISORY → Note gaps, /orchestrate with caution
+    ├─ RESEARCH_NEEDED → Offer /repo-research or sage:
+    └─ BLOCKED → Report, await user decision
+```
+
+## Gap Resolution
+
+For RESEARCH_NEEDED results, use Sage for gap resolution:
+
+```
+sage: resolve gaps for [feature]
+```
+
+Sage will:
+
+- Read the readiness check output
+- Research identified gaps
+- Extract patterns to LEARNINGS.md
+- Recommend re-running readiness check
+
+## Related
+
+- `.claude/skills/readiness-check.md` - Full skill definition
+- `.claude/agents/supervisor.md` - Supervisor integration
+- `.claude/agents/sage.md` - Gap resolution workflow
+- `/repo-research` - External repository research
+- `/orchestrate` - Feature orchestration

--- a/.claude/skills/readiness-check.md
+++ b/.claude/skills/readiness-check.md
@@ -1,27 +1,520 @@
+---
+name: readiness-checker
+tools: Read, Glob, Grep, Bash
+model: sonnet
+description: Assess capability gaps (knowledge, tools, experience) before committing to work. Returns READY, ADVISORY, RESEARCH_NEEDED, or BLOCKED with detailed gap analysis.
+---
+
 # Readiness Check Skill
 
-> **Status**: Placeholder - Implementation pending
+**Purpose**: Assess capability gaps (knowledge, tools, experience) before committing to work, enabling informed decisions about proceeding, researching, or requesting clarification.
 
-## Purpose
+**Owner**: Supervisor persona (auto-invocation), any agent (manual)
 
-Capability gap analysis skill for proactive identification of knowledge or tool gaps before committing to work.
+**Invocation**: `/readiness-check [task description]` or automatic via Supervisor at new request intake
 
-## Planned Features
+---
 
-- [ ] Analyze requested work against current capabilities
-- [ ] Identify knowledge gaps requiring research
-- [ ] Identify tool gaps requiring installation/configuration
-- [ ] Integrate with Supervisor for automatic pre-work assessment
-- [ ] Trigger research/upskill workflow when gaps found
+## When to Use
 
-## Usage (Planned)
+**Automatic Triggers** (Supervisor-managed):
 
+- New feature request received
+- After scope clarification, before `/orchestrate`
+- When user provides ambiguous or complex requirements
+
+**Manual Triggers**:
+
+- Before committing to unfamiliar work
+- When uncertain about tool availability
+- Before estimating effort for new integrations
+- When onboarding to new domain areas
+
+**Do NOT use for**:
+
+- Simple, well-understood tasks (typo fixes, minor edits)
+- Tasks already in progress with validated context
+- Pure documentation or research tasks
+
+---
+
+## Assessment Dimensions
+
+The readiness check evaluates three dimensions, each contributing to an overall score:
+
+### 1. Knowledge Assessment (40% weight)
+
+**What to Check**:
+
+- `docs/reference/LEARNINGS.md` - Proven patterns matching the task
+- `.claude/skills/` - Existing skills for similar workflows
+- `docs/specs/ADR_INDEX.md` - Relevant architecture decisions
+- `docs/for_chris/` - Educational materials on the domain
+- Prior art in codebase - Similar implementations
+
+**Search Commands**:
+
+```bash
+# Search LEARNINGS.md for relevant patterns
+grep -i "[keywords]" docs/reference/LEARNINGS.md
+
+# Find related skills
+ls .claude/skills/ | grep -i "[domain]"
+
+# Search for prior implementations
+grep -r "[pattern]" models/ --include="*.sql"
 ```
-/readiness-check <task-description>
+
+**Scoring Rubric**:
+
+| Condition | Score |
+|-----------|-------|
+| Multiple proven patterns documented | 36-40 |
+| One or more relevant patterns found | 28-35 |
+| Related but not exact patterns | 16-27 |
+| No relevant patterns found | 0-15 |
+
+---
+
+### 2. Tools Assessment (30% weight)
+
+**What to Check**:
+
+- `pyproject.toml` - Required packages installed
+- MCP servers available - External integrations needed
+- Environment configuration - Secrets, connections
+- CLI tools - Required executables present
+
+**Verification Commands**:
+
+```bash
+# Check pyproject.toml for packages
+grep -E "dbt|pandas|[package]" pyproject.toml
+
+# Check MCP servers
+cat ~/.claude/settings.json | grep -i mcp
+
+# Verify CLI tools
+which gh dbt uv
+
+# Check dbt connection
+uv run dbt debug --quiet
 ```
+
+**Scoring Rubric**:
+
+| Condition | Score |
+|-----------|-------|
+| All required tools present and configured | 27-30 |
+| Most tools present, minor config needed | 20-26 |
+| Some tools missing, installable | 10-19 |
+| Critical tools missing or unavailable | 0-9 |
+
+---
+
+### 3. Experience Assessment (30% weight)
+
+**What to Check**:
+
+- `CHANGELOG.md` - Similar work completed before
+- Pattern maturity - How often has this been done
+- Novelty level - First-time vs routine work
+- Complexity indicators - Multi-agent vs single-agent
+
+**Search Commands**:
+
+```bash
+# Check CHANGELOG for similar features
+grep -i "[feature-type]" CHANGELOG.md
+
+# Count similar models
+ls models/staging/ | wc -l
+
+# Check for related PRs
+gh pr list --state merged --search "[keywords]" --limit 5
+```
+
+**Scoring Rubric**:
+
+| Condition | Score |
+|-----------|-------|
+| Routine work with 5+ prior examples | 27-30 |
+| Familiar pattern with 2-4 examples | 20-26 |
+| Partially novel with 1 example | 10-19 |
+| Completely novel, no prior examples | 0-9 |
+
+---
+
+## Workflow Phases
+
+### Phase 1: Scope Extraction
+
+**Input**: Task description from user
+
+**Process**:
+
+1. Parse request for technical requirements
+2. Identify domain areas (dbt, Python, integrations)
+3. Extract key terms for searching
+4. Classify complexity (simple, moderate, complex)
+
+**Output**: Structured scope summary
+
+```markdown
+## Scope Summary
+- **Domain**: [dbt/python/integration/etc]
+- **Key Terms**: [extracted keywords]
+- **Complexity**: [simple/moderate/complex]
+- **Dependencies**: [identified dependencies]
+```
+
+---
+
+### Phase 2: Knowledge Assessment
+
+**Process**:
+
+1. Search LEARNINGS.md for pattern matches
+2. Search skills/ for workflow matches
+3. Search ADR_INDEX for architectural guidance
+4. Search codebase for prior implementations
+5. Calculate knowledge score
+
+**Commands**:
+
+```bash
+# Pattern search
+grep -i "[term1]\|[term2]" docs/reference/LEARNINGS.md
+grep -l "[term]" .claude/skills/*.md
+grep -r "[pattern]" models/ --include="*.sql" | head -5
+```
+
+---
+
+### Phase 3: Tool Assessment
+
+**Process**:
+
+1. Identify required packages from scope
+2. Check pyproject.toml for presence
+3. Verify MCP servers if needed
+4. Check environment configuration
+5. Calculate tool score
+
+**Commands**:
+
+```bash
+# Package check
+grep -E "[package1]|[package2]" pyproject.toml
+
+# MCP check (if integration needed)
+cat ~/.claude/settings.json 2>/dev/null | grep -c mcp || echo "0"
+
+# Environment check
+env | grep -E "DBT|DATABASE|API" | wc -l
+```
+
+---
+
+### Phase 4: Experience Assessment
+
+**Process**:
+
+1. Search CHANGELOG for similar work
+2. Count prior implementations
+3. Assess novelty level
+4. Identify complexity factors
+5. Calculate experience score
+
+**Commands**:
+
+```bash
+# CHANGELOG search
+grep -c -i "[feature-type]" CHANGELOG.md
+
+# Count similar implementations
+find models/ -name "*[pattern]*" | wc -l
+```
+
+---
+
+### Phase 5: Gap Analysis
+
+**Process**:
+
+1. Compile scores from all dimensions
+2. Calculate composite score
+3. Identify specific gaps
+4. Classify gaps as BLOCKING or ADVISORY
+
+**Gap Classification**:
+
+| Gap Type | Classification | Example |
+|----------|----------------|---------|
+| Missing critical tool | BLOCKING | No dbt adapter for target database |
+| Missing package | ADVISORY | Can install with `uv add` |
+| No patterns documented | ADVISORY | Need research, not blocked |
+| No prior experience | ADVISORY | Higher effort, not blocked |
+| Missing MCP server | BLOCKING (if required) | External API integration |
+| Security/compliance unknown | BLOCKING | Needs clarification |
+
+---
+
+### Phase 6: Decision & Output
+
+**Score Thresholds**:
+
+| Score Range | Status | Action |
+|-------------|--------|--------|
+| 80-100 | READY | Proceed to `/orchestrate` |
+| 60-79 | ADVISORY | Note gaps, proceed with caution |
+| 40-59 | RESEARCH_NEEDED | Recommend `/repo-research` or `sage:` |
+| 0-39 | BLOCKED | Report blockers, await user decision |
+
+**Output Artifact**: `temp/READINESS_CHECK_[feature].md`
+
+---
+
+## Output Artifact Template
+
+```markdown
+# Readiness Check: [Feature Name]
+
+**Generated**: [timestamp]
+**Status**: [READY | ADVISORY | RESEARCH_NEEDED | BLOCKED]
+**Composite Score**: [X]/100
+
+---
+
+## Scope Summary
+
+- **Request**: [original request summary]
+- **Domain**: [identified domain]
+- **Complexity**: [simple | moderate | complex]
+- **Key Terms**: [term1, term2, term3]
+
+---
+
+## Assessment Results
+
+### Knowledge (Weight: 40%)
+**Score**: [X]/40
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| LEARNINGS.md patterns | [X found] | [relevant patterns] |
+| Skills available | [X found] | [skill names] |
+| ADR guidance | [yes/no] | [ADR references] |
+| Prior implementations | [X found] | [file paths] |
+
+**Gaps**:
+- [ ] [Gap description] — [BLOCKING/ADVISORY]
+
+### Tools (Weight: 30%)
+**Score**: [X]/30
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| Packages present | [yes/no] | [missing packages] |
+| MCP servers | [N/A or status] | [server names] |
+| Environment config | [yes/no] | [missing config] |
+| CLI tools | [yes/no] | [missing tools] |
+
+**Gaps**:
+- [ ] [Gap description] — [BLOCKING/ADVISORY]
+
+### Experience (Weight: 30%)
+**Score**: [X]/30
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| Prior similar work | [X instances] | [CHANGELOG refs] |
+| Pattern maturity | [routine/partial/novel] | [assessment] |
+| Complexity factors | [list] | [multi-agent, etc] |
+
+**Gaps**:
+- [ ] [Gap description] — [BLOCKING/ADVISORY]
+
+---
+
+## Recommendations
+
+### Immediate Actions
+1. [Action if READY or ADVISORY]
+
+### Research Needed (if applicable)
+- [ ] [Research topic] — `/repo-research [url]` or `sage: [query]`
+
+### Blockers (if applicable)
+- [ ] [Blocker description] — Requires: [user decision/tool install/clarification]
+
+---
+
+## Decision
+
+**Status**: [READY | ADVISORY | RESEARCH_NEEDED | BLOCKED]
+
+**Next Step**:
+- [READY] Proceed to `/orchestrate [feature]`
+- [ADVISORY] Proceed with noted gaps; monitor for issues
+- [RESEARCH_NEEDED] Run `/repo-research` or `sage: research` first
+- [BLOCKED] Resolve blockers before proceeding; user decision required
+```
+
+---
 
 ## Integration Points
 
-- Supervisor agent (auto-invoke before work commitment)
-- Research workflow (when knowledge gaps found)
-- Tool installation workflow (when tool gaps found)
+### Supervisor Integration
+
+The Supervisor invokes `/readiness-check` automatically:
+
+```
+[After Scope Clarification]
+    │
+    ├─ Run /readiness-check [request]
+    │
+    ├─ READY (≥80) → Proceed to /orchestrate
+    ├─ ADVISORY (60-79) → Note gaps, proceed with caution
+    ├─ RESEARCH_NEEDED (40-59) → Offer /repo-research or sage:
+    └─ BLOCKED (<40) → Report blockers, await user decision
+```
+
+### Sage Integration
+
+For RESEARCH_NEEDED results, Sage can perform gap resolution:
+
+```
+sage: resolve gaps for [feature]
+    - Read: temp/READINESS_CHECK_[feature].md
+    - Research identified gaps
+    - Update LEARNINGS.md with findings
+    - Re-assess readiness
+```
+
+### WORKFLOW_STATE.md Recording
+
+When readiness check completes, Supervisor records result:
+
+```yaml
+### Track: feat/example-feature (ACTIVE)
+- **Readiness Check**: 2026-01-31T10:00:00Z
+- **Readiness Score**: 75/100 (ADVISORY)
+- **Gaps Noted**: Missing dbt_expectations patterns
+```
+
+---
+
+## Examples
+
+### Example 1: READY Path
+
+**Request**: "Add unique test to existing staging model"
+
+**Assessment**:
+
+- Knowledge: 38/40 (many testing patterns in LEARNINGS.md)
+- Tools: 30/30 (all dbt tools present)
+- Experience: 28/30 (100+ tests already exist)
+- **Total: 96/100 — READY**
+
+**Output**: Proceed to orchestrate immediately.
+
+---
+
+### Example 2: ADVISORY Path
+
+**Request**: "Add dbt_expectations tests to staging models"
+
+**Assessment**:
+
+- Knowledge: 25/40 (dbt testing patterns exist, dbt_expectations not documented)
+- Tools: 22/30 (dbt_expectations not in pyproject.toml but installable)
+- Experience: 15/30 (no prior dbt_expectations usage)
+- **Total: 62/100 — ADVISORY**
+
+**Gaps**:
+
+- [ ] dbt_expectations not installed — ADVISORY (installable)
+- [ ] No documented patterns for dbt_expectations — ADVISORY (can research)
+
+**Output**: Proceed with gaps noted; recommend installing package first.
+
+---
+
+### Example 3: RESEARCH_NEEDED Path
+
+**Request**: "Implement Tuva clinical data mart integration"
+
+**Assessment**:
+
+- Knowledge: 15/40 (no Tuva patterns documented)
+- Tools: 20/30 (healthcare connectors not configured)
+- Experience: 8/30 (no prior Tuva work)
+- **Total: 43/100 — RESEARCH_NEEDED**
+
+**Gaps**:
+
+- [ ] No Tuva patterns in LEARNINGS.md — ADVISORY
+- [ ] Healthcare connector MCP not configured — BLOCKING (if required)
+- [ ] No prior Tuva implementations — ADVISORY
+
+**Output**: Recommend `/repo-research https://github.com/tuva-health/tuva` first.
+
+---
+
+### Example 4: BLOCKED Path
+
+**Request**: "Add Snowflake connector for production deployment"
+
+**Assessment**:
+
+- Knowledge: 20/40 (some Snowflake patterns exist)
+- Tools: 5/30 (dbt-snowflake not installed, no credentials)
+- Experience: 10/30 (no Snowflake usage in project)
+- **Total: 35/100 — BLOCKED**
+
+**Gaps**:
+
+- [ ] dbt-snowflake adapter not installed — BLOCKING
+- [ ] Snowflake credentials not configured — BLOCKING
+- [ ] No Snowflake account provisioned — BLOCKING
+
+**Output**: Cannot proceed. User must provision Snowflake and configure credentials.
+
+---
+
+## Command-Line Options
+
+```
+/readiness-check [task description]
+    --dimension=knowledge|tools|experience  # Check single dimension only
+    --verbose                               # Show all search results
+    --skip-output                          # Don't write artifact file
+```
+
+---
+
+## Checklist
+
+Before completing readiness check:
+
+- [ ] Scope extracted from request
+- [ ] Knowledge assessment completed (LEARNINGS, skills, prior art)
+- [ ] Tools assessment completed (packages, MCP, environment)
+- [ ] Experience assessment completed (CHANGELOG, prior work)
+- [ ] Gaps classified as BLOCKING or ADVISORY
+- [ ] Composite score calculated
+- [ ] Status determined (READY/ADVISORY/RESEARCH_NEEDED/BLOCKED)
+- [ ] Artifact written to `temp/READINESS_CHECK_[feature].md`
+- [ ] Handoff to Supervisor or next action recommended
+
+---
+
+## See Also
+
+- `.claude/commands/readiness-check.md` - Command reference
+- `.claude/agents/supervisor.md` - Supervisor integration
+- `.claude/agents/sage.md` - Gap resolution research
+- `.claude/skills/repo-research.md` - External repository research
+- `docs/reference/LEARNINGS.md` - Pattern reference

--- a/.claude/skills/readiness-check.md
+++ b/.claude/skills/readiness-check.md
@@ -1,0 +1,27 @@
+# Readiness Check Skill
+
+> **Status**: Placeholder - Implementation pending
+
+## Purpose
+
+Capability gap analysis skill for proactive identification of knowledge or tool gaps before committing to work.
+
+## Planned Features
+
+- [ ] Analyze requested work against current capabilities
+- [ ] Identify knowledge gaps requiring research
+- [ ] Identify tool gaps requiring installation/configuration
+- [ ] Integrate with Supervisor for automatic pre-work assessment
+- [ ] Trigger research/upskill workflow when gaps found
+
+## Usage (Planned)
+
+```
+/readiness-check <task-description>
+```
+
+## Integration Points
+
+- Supervisor agent (auto-invoke before work commitment)
+- Research workflow (when knowledge gaps found)
+- Tool installation workflow (when tool gaps found)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,7 @@ temp/AGENT_REPORTS/[feature-name]/
 | `/branch` | Branch creation via git-master |
 | `/plan` | Structured planning |
 | `/dbt-run` | Execute dbt commands |
+| `/readiness-check` | Assess capability gaps before new work |
 
 ## Git Worktrees (Parallel Development)
 


### PR DESCRIPTION
## Summary

Adding a `/readiness-check` skill for capability gap analysis that enables proactive identification of knowledge or tool gaps before committing to work.

## Scope

- **Add `/readiness-check` skill** - Analyze requested work against current capabilities and identify gaps
- **Update Supervisor orchestration** - Auto-invoke readiness check before committing to new work
- **Enable research/upskill workflow** - When gaps are found, trigger appropriate learning or tooling acquisition

## Status

- [ ] Implementation
- [ ] Tests
- [ ] Documentation
- [ ] Ready for review

---

*Draft PR for worktree: `../dbt-playground--readiness-check`*

Related to #129