### PR TITLE
feat(v0.8): singular business rule tests (Phase 3)

### DIFF
--- a/.phase3-tracking
+++ b/.phase3-tracking
@@ -1,0 +1,6 @@
+# Phase 3 Singular Tests Track
+
+Status: Active
+Branch: feat/v0.8-singular-tests
+Started: 2026-02-01
+

--- a/dbt_project/tests/data_quality/assert_encounter_timestamps_valid.sql
+++ b/dbt_project/tests/data_quality/assert_encounter_timestamps_valid.sql
@@ -1,0 +1,19 @@
+-- Test: Encounter Timestamp Validation
+-- Purpose: Verify encounter_end_at >= encounter_start_at for all encounters
+-- Severity: error
+-- Returns rows that violate this constraint (should return 0 rows)
+
+with violations as (
+    select
+        encounter_key
+        , encounter_id
+        , patient_id
+        , encounter_start_at
+        , encounter_end_at
+        , encounter_class
+    from {{ ref('fct_encounters') }}
+    where encounter_end_at < encounter_start_at
+)
+
+select *
+from violations

--- a/dbt_project/tests/data_quality/assert_medication_dates_valid.sql
+++ b/dbt_project/tests/data_quality/assert_medication_dates_valid.sql
@@ -1,0 +1,34 @@
+-- Test: Medication Date Validation (Stretch Goal)
+-- Purpose: Verify medication_end_at >= medication_start_at where end date exists
+-- Severity: error
+-- Returns rows that violate this constraint (should return 0 rows)
+
+with medications_from_clinical_events as (
+    select
+        clinical_event_key
+        , event_id as medication_id
+        , patient_id
+        , encounter_id
+        , event_start_date as medication_start_date
+        , event_end_date as medication_end_date
+        , description as medication_description
+    from {{ ref('fct_clinical_events') }}
+    where event_type = 'MEDICATION'
+),
+
+violations as (
+    select
+        clinical_event_key
+        , medication_id
+        , patient_id
+        , encounter_id
+        , medication_start_date
+        , medication_end_date
+        , medication_description
+    from medications_from_clinical_events
+    where medication_end_date is not null
+      and medication_end_date < medication_start_date
+)
+
+select *
+from violations

--- a/dbt_project/tests/data_quality/assert_no_future_dates.sql
+++ b/dbt_project/tests/data_quality/assert_no_future_dates.sql
@@ -1,0 +1,163 @@
+-- Test: No Future Dates Validation
+-- Purpose: Comprehensive check for future dates across all critical date columns
+-- Severity: warn (Phase 2 already covers this via individual column tests)
+-- Returns rows where any date is > current_date (should return 0 rows)
+
+{{
+    config(
+        severity = 'warn'
+    )
+}}
+
+with staging_patients_violations as (
+    select
+        'stg_synthea__patients' as source_model
+        , patient_id as record_id
+        , 'birth_date' as column_name
+        , birth_date as date_value
+    from {{ ref('stg_synthea__patients') }}
+    where birth_date > current_date
+
+    union all
+
+    select
+        'stg_synthea__patients' as source_model
+        , patient_id as record_id
+        , 'death_date' as column_name
+        , death_date as date_value
+    from {{ ref('stg_synthea__patients') }}
+    where death_date > current_date
+),
+
+staging_encounters_violations as (
+    select
+        'stg_synthea__encounters' as source_model
+        , encounter_id as record_id
+        , 'encounter_start_at' as column_name
+        , cast(encounter_start_at as date) as date_value
+    from {{ ref('stg_synthea__encounters') }}
+    where cast(encounter_start_at as date) > current_date
+
+    union all
+
+    select
+        'stg_synthea__encounters' as source_model
+        , encounter_id as record_id
+        , 'encounter_end_at' as column_name
+        , cast(encounter_end_at as date) as date_value
+    from {{ ref('stg_synthea__encounters') }}
+    where cast(encounter_end_at as date) > current_date
+),
+
+staging_conditions_violations as (
+    select
+        'stg_synthea__conditions' as source_model
+        , condition_id as record_id
+        , 'condition_start_date' as column_name
+        , condition_start_date as date_value
+    from {{ ref('stg_synthea__conditions') }}
+    where condition_start_date > current_date
+
+    union all
+
+    select
+        'stg_synthea__conditions' as source_model
+        , condition_id as record_id
+        , 'condition_end_date' as column_name
+        , condition_end_date as date_value
+    from {{ ref('stg_synthea__conditions') }}
+    where condition_end_date > current_date
+),
+
+staging_medications_violations as (
+    select
+        'stg_synthea__medications' as source_model
+        , medication_id as record_id
+        , 'medication_start_at' as column_name
+        , cast(medication_start_at as date) as date_value
+    from {{ ref('stg_synthea__medications') }}
+    where cast(medication_start_at as date) > current_date
+),
+
+staging_procedures_violations as (
+    select
+        'stg_synthea__procedures' as source_model
+        , procedure_id as record_id
+        , 'procedure_at' as column_name
+        , cast(procedure_at as date) as date_value
+    from {{ ref('stg_synthea__procedures') }}
+    where cast(procedure_at as date) > current_date
+),
+
+staging_observations_violations as (
+    select
+        'stg_synthea__observations' as source_model
+        , observation_id as record_id
+        , 'observation_at' as column_name
+        , cast(observation_at as date) as date_value
+    from {{ ref('stg_synthea__observations') }}
+    where cast(observation_at as date) > current_date
+),
+
+dim_patients_violations as (
+    select
+        'dim_patients' as source_model
+        , cast(patient_key as varchar) as record_id
+        , 'valid_from' as column_name
+        , valid_from as date_value
+    from {{ ref('dim_patients') }}
+    where valid_from > current_date
+      and patient_key != -1  -- exclude unknown member
+
+    union all
+
+    select
+        'dim_patients' as source_model
+        , cast(patient_key as varchar) as record_id
+        , 'valid_to' as column_name
+        , valid_to as date_value
+    from {{ ref('dim_patients') }}
+    where valid_to > current_date
+      and patient_key != -1  -- exclude unknown member
+),
+
+fct_clinical_events_violations as (
+    select
+        'fct_clinical_events' as source_model
+        , cast(clinical_event_key as varchar) as record_id
+        , 'event_start_date' as column_name
+        , event_start_date as date_value
+    from {{ ref('fct_clinical_events') }}
+    where event_start_date > current_date
+
+    union all
+
+    select
+        'fct_clinical_events' as source_model
+        , cast(clinical_event_key as varchar) as record_id
+        , 'event_end_date' as column_name
+        , event_end_date as date_value
+    from {{ ref('fct_clinical_events') }}
+    where event_end_date > current_date
+),
+
+all_violations as (
+    select * from staging_patients_violations
+    union all
+    select * from staging_encounters_violations
+    union all
+    select * from staging_conditions_violations
+    union all
+    select * from staging_medications_violations
+    union all
+    select * from staging_procedures_violations
+    union all
+    select * from staging_observations_violations
+    union all
+    select * from dim_patients_violations
+    union all
+    select * from fct_clinical_events_violations
+)
+
+select *
+from all_violations

--- a/dbt_project/tests/data_quality/assert_no_orphaned_clinical_events.sql
+++ b/dbt_project/tests/data_quality/assert_no_orphaned_clinical_events.sql
@@ -1,0 +1,65 @@
+-- Test: No Orphaned Clinical Events
+-- Purpose: Verify all clinical events (conditions, medications, procedures) reference valid encounters
+-- Severity: error
+-- Returns rows where the encounter_key = -1 (unknown member), indicating orphaned events
+
+with clinical_events_with_missing_encounters as (
+    select
+        clinical_event_key
+        , event_type
+        , event_id
+        , patient_id
+        , encounter_id
+        , encounter_key
+        , event_start_date
+        , description
+    from {{ ref('fct_clinical_events') }}
+    where encounter_key = -1
+      and encounter_id is not null  -- only flag if encounter_id was provided but not found
+),
+
+-- additionally check for events with null encounter_id (data quality issue)
+events_with_null_encounter_id as (
+    select
+        clinical_event_key
+        , event_type
+        , event_id
+        , patient_id
+        , encounter_id
+        , encounter_key
+        , event_start_date
+        , description
+    from {{ ref('fct_clinical_events') }}
+    where encounter_id is null
+),
+
+violations as (
+    select
+        clinical_event_key
+        , event_type
+        , event_id
+        , patient_id
+        , encounter_id
+        , encounter_key
+        , event_start_date
+        , description
+        , 'encounter_not_found' as violation_type
+    from clinical_events_with_missing_encounters
+
+    union all
+
+    select
+        clinical_event_key
+        , event_type
+        , event_id
+        , patient_id
+        , encounter_id
+        , encounter_key
+        , event_start_date
+        , description
+        , 'null_encounter_id' as violation_type
+    from events_with_null_encounter_id
+)
+
+select *
+from violations

--- a/dbt_project/tests/data_quality/assert_patient_dates_valid.sql
+++ b/dbt_project/tests/data_quality/assert_patient_dates_valid.sql
@@ -1,0 +1,19 @@
+-- Test: Patient Date Validation
+-- Purpose: Verify death_date >= birth_date when death_date is NOT NULL
+-- Severity: error
+-- Returns rows that violate this constraint (should return 0 rows)
+
+with violations as (
+    select
+        patient_key
+        , patient_id
+        , full_name
+        , birth_date
+        , death_date
+    from {{ ref('dim_patients') }}
+    where death_date is not null
+      and death_date < birth_date
+)
+
+select *
+from violations


### PR DESCRIPTION
## Summary

Phase 3 of v0.8 data quality enhancements: implementing singular (custom) tests for complex business rules across the dbt pipeline.

**Scope**: Issue #36 (Singular business rule tests)

## Acceptance Criteria

- [ ] Encounter timestamp validation: encounter_end_at >= encounter_start_at
- [ ] Patient date validation: death_date >= birth_date (when applicable)
- [ ] Orphaned clinical events check: all conditions/medications/procedures reference valid encounters
- [ ] Future dates validation: no future dates in inappropriate columns
- [ ] All singular tests pass (or document expected failures)

## Architecture

**Files to create**:
- `tests/data_quality/assert_encounter_timestamps_valid.sql`
- `tests/data_quality/assert_patient_dates_valid.sql`
- `tests/data_quality/assert_no_orphaned_clinical_events.sql`
- `tests/data_quality/assert_no_future_dates.sql`

## Status

- [ ] Phase 3 implementation in progress
- [ ] Tests passing locally
- [ ] Ready for Phase 4 validation

---

Closes #36

🤖 Parallel track for v0.8 Phase 3 launched by Supervisor