### PR TITLE
feat(unit-tests): add cute-dbt dogfooding unit_tests on dim_payers + mart_dq_summary

### DIFF
--- a/dbt_project/models/marts/analytics/_analytics__models.yml
+++ b/dbt_project/models/marts/analytics/_analytics__models.yml
@@ -1287,3 +1287,101 @@ models:
 
       - name: _generated_at
         description: "Timestamp when summary was generated"
+
+
+# ============================================================================
+# UNIT TESTS
+# ============================================================================
+# These unit_tests are authored to exercise the cute-dbt unit-test explorer
+# (https://github.com/breezy-bays-labs/cute-dbt) against this playground's
+# UNION-bearing analytics mart. They intentionally vary EXPECT formats
+# (csv + dict) to demonstrate cute-dbt's renderer against dbt's three
+# unit_test fixture formats (dict, csv, sql) — given uses sql format
+# universally so the tests pass standalone without seeded Synthea data.
+
+unit_tests:
+  - name: test_mart_dq_summary_combines_encounter_and_medication_metrics
+    description: |
+      mart_dq_summary UNION-ALLs metrics from stg_synthea__encounters
+      and stg_synthea__medications. This test mocks two encounter rows
+      (one invalid) and two medication rows (both invalid), then asserts
+      the per-entity counts + quarantine rate. Uses sql format for the
+      GIVEN mocks (no upstream introspection required → passes
+      standalone without seeded Synthea data) and csv format for the
+      EXPECT — demonstrates the compact tabular form for assertions.
+    model: mart_dq_summary
+    given:
+      - input: ref('stg_synthea__encounters')
+        format: sql
+        rows: |
+          select cast(false as boolean) as is_dq_valid
+            , cast(false as boolean) as valid_encounter_timestamps
+            , cast(true  as boolean) as no_future_encounter_dates
+            , cast(true  as boolean) as end_after_1900
+            , cast(true  as boolean) as start_after_1900
+          union all
+          select cast(true  as boolean) as is_dq_valid
+            , cast(true  as boolean) as valid_encounter_timestamps
+            , cast(true  as boolean) as no_future_encounter_dates
+            , cast(true  as boolean) as end_after_1900
+            , cast(true  as boolean) as start_after_1900
+      - input: ref('stg_synthea__medications')
+        format: sql
+        rows: |
+          select cast(false as boolean) as is_dq_valid
+            , cast(false as boolean) as valid_medication_dates
+            , cast(true  as boolean) as no_future_medication_dates
+            , cast(true  as boolean) as start_after_1900
+            , cast(true  as boolean) as end_after_1900_if_present
+          union all
+          select cast(false as boolean) as is_dq_valid
+            , cast(true  as boolean) as valid_medication_dates
+            , cast(false as boolean) as no_future_medication_dates
+            , cast(true  as boolean) as start_after_1900
+            , cast(true  as boolean) as end_after_1900_if_present
+    expect:
+      format: csv
+      rows: |
+        entity_type,quarantined_count,total_count,quarantine_rate_pct,failed_timestamp_validations
+        encounters,1,2,50.00,1
+        medications,2,2,100.00,1
+
+  - name: test_mart_dq_summary_zero_quarantined_when_all_valid
+    description: |
+      mart_dq_summary should report zero quarantined_count and 0.00
+      quarantine_rate_pct when every upstream row passes data-quality
+      validations. Uses sql format for the GIVEN mocks and dict format
+      for the EXPECT — dict expects only compare listed columns, so
+      non-deterministic outputs (`_generated_at` from
+      `current_timestamp`) are excluded from comparison.
+    model: mart_dq_summary
+    given:
+      - input: ref('stg_synthea__encounters')
+        format: sql
+        rows: |
+          select
+            true as is_dq_valid
+            , true as valid_encounter_timestamps
+            , true as no_future_encounter_dates
+            , true as end_after_1900
+            , true as start_after_1900
+      - input: ref('stg_synthea__medications')
+        format: sql
+        rows: |
+          select
+            true as is_dq_valid
+            , true as valid_medication_dates
+            , true as no_future_medication_dates
+            , true as start_after_1900
+            , true as end_after_1900_if_present
+    expect:
+      format: dict
+      rows:
+        - entity_type: 'encounters'
+          quarantined_count: 0
+          total_count: 1
+          quarantine_rate_pct: 0.00
+        - entity_type: 'medications'
+          quarantined_count: 0
+          total_count: 1
+          quarantine_rate_pct: 0.00

--- a/dbt_project/models/marts/core/_core__models.yml
+++ b/dbt_project/models/marts/core/_core__models.yml
@@ -1144,3 +1144,59 @@ models:
 
       - name: _loaded_at
         description: Timestamp when record was loaded
+
+
+# ============================================================================
+# UNIT TESTS
+# ============================================================================
+# These unit_tests are authored to exercise the cute-dbt unit-test explorer
+# (https://github.com/breezy-bays-labs/cute-dbt) against this playground's
+# UNION-bearing mart models. Each test mocks a small set of upstream rows
+# and asserts the SQL transformation produces the expected shape.
+
+unit_tests:
+  - name: test_dim_payers_injects_unknown_sentinel
+    description: |
+      dim_payers UNION-ALLs an unknown-member sentinel row (payer_key = -1)
+      with the sequenced source rows. This test verifies the sentinel
+      survives the union and the sequenced rows are surrogate-keyed
+      starting at 1. Uses sql format for the GIVEN mock (a single inline
+      SELECT) so the test passes standalone without seeded Synthea data,
+      and dict format for EXPECT — dict expects only compare listed
+      columns, so non-deterministic outputs (`_loaded_at`) are skipped.
+    model: dim_payers
+    given:
+      - input: ref('stg_synthea__payers')
+        format: sql
+        rows: |
+          select
+            cast('a00000aa-0000-0000-0000-000000000001' as varchar) as payer_id
+            , cast('Acme Health' as varchar) as payer_name
+            , cast('1 Acme Way' as varchar) as address
+            , cast('Boston' as varchar) as city
+            , cast('MA' as varchar) as state
+            , cast('02101' as varchar) as zip_code
+            , cast('555-0100' as varchar) as phone
+            , cast(1000.0 as double) as amount_covered
+            , cast(250.0 as double) as amount_uncovered
+            , cast(1250.0 as double) as revenue
+            , cast(10 as bigint) as covered_encounters
+            , cast(2 as bigint) as uncovered_encounters
+            , cast(5 as bigint) as covered_medications
+            , cast(1 as bigint) as uncovered_medications
+            , cast(3 as bigint) as covered_procedures
+            , cast(0 as bigint) as uncovered_procedures
+            , cast(4 as bigint) as covered_immunizations
+            , cast(0 as bigint) as uncovered_immunizations
+            , cast(8 as bigint) as unique_customers
+            , cast(0.85 as double) as average_quality_of_life_score
+            , cast(96 as bigint) as member_months
+    expect:
+      format: dict
+      rows:
+        - payer_key: -1
+          payer_id: 'UNKNOWN'
+          payer_name: 'Unknown Payer'
+        - payer_key: 1
+          payer_id: 'a00000aa-0000-0000-0000-000000000001'
+          payer_name: 'Acme Health'


### PR DESCRIPTION
## Summary

Adds 3 unit_tests exercising the playground's UNION-bearing mart
models. Doubles as source material for [cute-dbt](https://github.com/breezy-bays-labs/cute-dbt)
dogfooding (see [cute-dbt#39](https://github.com/breezy-bays-labs/cute-dbt/issues/39))
— the manifest output from this branch is the input fixture for
cute-dbt's first richer example report against real dbt models.

## Changes

- Append `unit_tests:` block to `dbt_project/models/marts/core/_core__models.yml`
  with `test_dim_payers_injects_unknown_sentinel`.
- Append `unit_tests:` block to `dbt_project/models/marts/analytics/_analytics__models.yml`
  with `test_mart_dq_summary_combines_encounter_and_medication_metrics`
  and `test_mart_dq_summary_zero_quarantined_when_all_valid`.

Total: +154 lines across 2 YAML files. No SQL model changes, no
new fixtures, no Python.

## Related Issues

Related to cute-dbt#39 (cross-repo fixture-source dogfooding).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

All 3 tests verified locally with dbt-core 1.11.11 + dbt-duckdb 1.10.1:

```
$ dbt test --select "test_type:unit"
1 of 3 START unit_test dim_payers::test_dim_payers_injects_unknown_sentinel
2 of 3 START unit_test mart_dq_summary::test_mart_dq_summary_combines_encounter_and_medication_metrics
3 of 3 START unit_test mart_dq_summary::test_mart_dq_summary_zero_quarantined_when_all_valid
1 of 3 PASS dim_payers::test_dim_payers_injects_unknown_sentinel [PASS in 0.10s]
2 of 3 PASS mart_dq_summary::test_mart_dq_summary_combines_encounter_and_medication_metrics [PASS in 0.10s]
3 of 3 PASS mart_dq_summary::test_mart_dq_summary_zero_quarantined_when_all_valid [PASS in 0.10s]

Completed successfully
Done. PASS=3 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=3
```

All tests use `format: sql` for `given` inputs so they pass standalone
without requiring seeded Synthea source data (no `dbt build` of
staging models required). `expect` formats vary across `dict` + `csv`
to demonstrate the dbt 1.8+ unit-test fixture-format surface.

### Specific Test Cases

1. **`test_dim_payers_injects_unknown_sentinel`** — dim_payers
   UNION-ALLs an unknown-member sentinel row (`payer_key = -1`) with
   the sequenced source rows. Verifies the sentinel survives the
   union and source rows are surrogate-keyed starting at 1.
2. **`test_mart_dq_summary_combines_encounter_and_medication_metrics`**
   — mart_dq_summary UNION-ALLs metrics from `stg_synthea__encounters`
   and `stg_synthea__medications`. Mocks 2 encounter rows (one
   invalid) + 2 medication rows (both invalid) and asserts per-entity
   counts + quarantine rate.
3. **`test_mart_dq_summary_zero_quarantined_when_all_valid`** — the
   inverse: zero quarantined_count + 0.00 quarantine_rate_pct when
   every upstream row passes DQ validation. Uses dict expect to
   sidestep non-deterministic `_generated_at` (current_timestamp).

### Manual Testing

UI-specific test items (Chrome/Firefox/Safari/localStorage) are N/A —
this PR adds dbt YAML only, no application code changes.

## Notes

- **Engine compatibility**: tests pass with dbt-core 1.11.x. dbt-fusion
  2.0.0-preview currently blocks parse on the playground's deprecated
  test-args YAML (~166 unrelated occurrences); migrating those is a
  separate dbt-autofix sweep tracked outside this PR.
- **No source data prerequisite**: the sql-format `given` mocks are
  self-contained inline SELECTs — `dbt build --empty` is NOT
  required first. Run `dbt test --select test_type:unit` after
  `dbt deps` and a single `dbt parse`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)