### PR TITLE
refactor(unit-tests): exercise dict + csv + sql fixture formats across the 3 cute-dbt dogfooding tests

### DIFF
--- a/dbt_project/README.md
+++ b/dbt_project/README.md
@@ -78,6 +78,57 @@ dbt_project/
 | `dbt docs generate` | Generate documentation |
 | `dbt docs serve` | Serve docs at localhost:8080 |
 
+## Unit tests (cute-dbt format coverage)
+
+Three unit_tests on `dim_payers` + `mart_dq_summary` exercise dbt's
+three fixture formats (`dict`, `csv`, `sql`) for the cute-dbt
+unit-test explorer ([breezy-bays-labs/cute-dbt#39 + #66](https://github.com/breezy-bays-labs/cute-dbt/issues/66)).
+
+**Format coverage:**
+
+| Test | Given format | Expect format | Demonstrates |
+|---|---|---|---|
+| `test_dim_payers_injects_unknown_sentinel` | dict | dict | Compact key-value mock for many columns |
+| `test_mart_dq_summary_combines_encounter_and_medication_metrics` | csv | csv | Tabular form for repeated boolean columns |
+| `test_mart_dq_summary_zero_quarantined_when_all_valid` | sql | dict | Inline SELECT mock when fine-grained casts matter |
+
+**Execution prerequisite — dict and csv given formats**: dbt's
+unit-test framework introspects the upstream relation's schema to
+NULL-fill columns not provided in the mock. The introspection requires
+the upstream model to **exist** in the warehouse. With the default
+`:memory:` DuckDB profile, the upstream relations vanish between
+`run-operation` and `test` invocations, so `dbt test --select
+test_type:unit` fails. Two paths:
+
+1. **Persistent DuckDB target** (recommended for local dev). Add to
+   `~/.dbt/profiles.yml`:
+
+   ```yaml
+   healthcare_analytics:
+     outputs:
+       unit_test:
+         type: duckdb
+         path: 'target/playground-unit-test.duckdb'
+         threads: 4
+   ```
+
+   Then:
+
+   ```bash
+   uv run dbt run-operation load_synthea_sources --target unit_test
+   uv run dbt build --empty --select "+mart_dq_summary +dim_payers" --target unit_test
+   uv run dbt test --select "test_type:unit" --target unit_test
+   ```
+
+2. **Inline mock with `sql` format** for the `given` block (no
+   introspection required, passes standalone against `:memory:`). The
+   `test_mart_dq_summary_zero_quarantined_when_all_valid` test
+   demonstrates this pattern.
+
+The persistent-target approach is preferred when authoring new
+unit_tests because dict and csv given are more readable for
+multi-column mocks.
+
 ## Resources
 
 - [dbt Documentation](https://docs.getdbt.com/)

--- a/dbt_project/models/marts/analytics/_analytics__models.yml
+++ b/dbt_project/models/marts/analytics/_analytics__models.yml
@@ -1294,10 +1294,18 @@ models:
 # ============================================================================
 # These unit_tests are authored to exercise the cute-dbt unit-test explorer
 # (https://github.com/breezy-bays-labs/cute-dbt) against this playground's
-# UNION-bearing analytics mart. They intentionally vary EXPECT formats
-# (csv + dict) to demonstrate cute-dbt's renderer against dbt's three
-# unit_test fixture formats (dict, csv, sql) — given uses sql format
-# universally so the tests pass standalone without seeded Synthea data.
+# UNION-bearing analytics mart. They intentionally exercise different
+# fixture formats for `given` (and `expect` where relevant): one csv,
+# one sql. dim_payers (_core__models.yml) covers the dict format.
+# Together the three tests pin cute-dbt's renderer against every dbt
+# 1.8+ unit_test fixture format. See `_core__models.yml` for the third
+# test (test_dim_payers_injects_unknown_sentinel).
+#
+# **Test-execution prerequisite**: dict and csv given formats introspect
+# the upstream model's schema (to NULL-fill unspecified columns). Run
+# `dbt run-operation load_synthea_sources` against a persistent DuckDB
+# target (see `playground README.md`) before `dbt test --select
+# test_type:unit`.
 
 unit_tests:
   - name: test_mart_dq_summary_combines_encounter_and_medication_metrics
@@ -1305,40 +1313,23 @@ unit_tests:
       mart_dq_summary UNION-ALLs metrics from stg_synthea__encounters
       and stg_synthea__medications. This test mocks two encounter rows
       (one invalid) and two medication rows (both invalid), then asserts
-      the per-entity counts + quarantine rate. Uses sql format for the
-      GIVEN mocks (no upstream introspection required → passes
-      standalone without seeded Synthea data) and csv format for the
-      EXPECT — demonstrates the compact tabular form for assertions.
+      the per-entity counts + quarantine rate. Uses csv format for both
+      GIVEN and EXPECT — compact tabular form across many boolean
+      dq-flag columns.
     model: mart_dq_summary
     given:
       - input: ref('stg_synthea__encounters')
-        format: sql
+        format: csv
         rows: |
-          select cast(false as boolean) as is_dq_valid
-            , cast(false as boolean) as valid_encounter_timestamps
-            , cast(true  as boolean) as no_future_encounter_dates
-            , cast(true  as boolean) as end_after_1900
-            , cast(true  as boolean) as start_after_1900
-          union all
-          select cast(true  as boolean) as is_dq_valid
-            , cast(true  as boolean) as valid_encounter_timestamps
-            , cast(true  as boolean) as no_future_encounter_dates
-            , cast(true  as boolean) as end_after_1900
-            , cast(true  as boolean) as start_after_1900
+          is_dq_valid,valid_encounter_timestamps,no_future_encounter_dates,end_after_1900,start_after_1900
+          false,false,true,true,true
+          true,true,true,true,true
       - input: ref('stg_synthea__medications')
-        format: sql
+        format: csv
         rows: |
-          select cast(false as boolean) as is_dq_valid
-            , cast(false as boolean) as valid_medication_dates
-            , cast(true  as boolean) as no_future_medication_dates
-            , cast(true  as boolean) as start_after_1900
-            , cast(true  as boolean) as end_after_1900_if_present
-          union all
-          select cast(false as boolean) as is_dq_valid
-            , cast(true  as boolean) as valid_medication_dates
-            , cast(false as boolean) as no_future_medication_dates
-            , cast(true  as boolean) as start_after_1900
-            , cast(true  as boolean) as end_after_1900_if_present
+          is_dq_valid,valid_medication_dates,no_future_medication_dates,start_after_1900,end_after_1900_if_present
+          false,false,true,true,true
+          false,true,false,true,true
     expect:
       format: csv
       rows: |

--- a/dbt_project/models/marts/core/_core__models.yml
+++ b/dbt_project/models/marts/core/_core__models.yml
@@ -1160,37 +1160,36 @@ unit_tests:
       dim_payers UNION-ALLs an unknown-member sentinel row (payer_key = -1)
       with the sequenced source rows. This test verifies the sentinel
       survives the union and the sequenced rows are surrogate-keyed
-      starting at 1. Uses sql format for the GIVEN mock (a single inline
-      SELECT) so the test passes standalone without seeded Synthea data,
-      and dict format for EXPECT — dict expects only compare listed
-      columns, so non-deterministic outputs (`_loaded_at`) are skipped.
+      starting at 1. Uses dbt's dict format for both GIVEN and EXPECT —
+      dict format only compares listed columns, so non-deterministic
+      outputs (`_loaded_at` via `current_timestamp`) are excluded from
+      assertion automatically.
     model: dim_payers
     given:
       - input: ref('stg_synthea__payers')
-        format: sql
-        rows: |
-          select
-            cast('a00000aa-0000-0000-0000-000000000001' as varchar) as payer_id
-            , cast('Acme Health' as varchar) as payer_name
-            , cast('1 Acme Way' as varchar) as address
-            , cast('Boston' as varchar) as city
-            , cast('MA' as varchar) as state
-            , cast('02101' as varchar) as zip_code
-            , cast('555-0100' as varchar) as phone
-            , cast(1000.0 as double) as amount_covered
-            , cast(250.0 as double) as amount_uncovered
-            , cast(1250.0 as double) as revenue
-            , cast(10 as bigint) as covered_encounters
-            , cast(2 as bigint) as uncovered_encounters
-            , cast(5 as bigint) as covered_medications
-            , cast(1 as bigint) as uncovered_medications
-            , cast(3 as bigint) as covered_procedures
-            , cast(0 as bigint) as uncovered_procedures
-            , cast(4 as bigint) as covered_immunizations
-            , cast(0 as bigint) as uncovered_immunizations
-            , cast(8 as bigint) as unique_customers
-            , cast(0.85 as double) as average_quality_of_life_score
-            , cast(96 as bigint) as member_months
+        format: dict
+        rows:
+          - payer_id: 'a00000aa-0000-0000-0000-000000000001'
+            payer_name: 'Acme Health'
+            address: '1 Acme Way'
+            city: 'Boston'
+            state: 'MA'
+            zip_code: '02101'
+            phone: '555-0100'
+            amount_covered: 1000.0
+            amount_uncovered: 250.0
+            revenue: 1250.0
+            covered_encounters: 10
+            uncovered_encounters: 2
+            covered_medications: 5
+            uncovered_medications: 1
+            covered_procedures: 3
+            uncovered_procedures: 0
+            covered_immunizations: 4
+            uncovered_immunizations: 0
+            unique_customers: 8
+            average_quality_of_life_score: 0.85
+            member_months: 96
     expect:
       format: dict
       rows:


### PR DESCRIPTION
## Summary

Follow-up to #290. The three unit_tests authored in #290 all used `format: sql` for `given` to avoid the upstream-introspection prerequisite that dict/csv require. Visual review of the rendered cute-dbt report surfaced two problems:

1. cute-dbt's renderer shows \"Fixture uses format: sql — not yet visualized\" for all three tests (tracked at [cute-dbt#66](https://github.com/breezy-bays-labs/cute-dbt/issues/66) — the renderer fix lands in the next cute-dbt PR).
2. Even after cute-dbt#66 ships, having every test on the same format defeats the format-coverage dogfooding.

This PR re-authors the three tests so each demonstrates a different fixture format end-to-end.

## Changes

| Test | Given format | Expect format | Demonstrates |
|---|---|---|---|
| `test_dim_payers_injects_unknown_sentinel` | dict | dict | Compact key-value mock for ~22 columns |
| `test_mart_dq_summary_combines_encounter_and_medication_metrics` | csv | csv | Tabular boolean grid (compact for many dq-flag columns) |
| `test_mart_dq_summary_zero_quarantined_when_all_valid` | sql | dict | Inline SELECT with explicit casts |

Plus `dbt_project/README.md` gains a new `## Unit tests (cute-dbt format coverage)` section documenting the persistent-DuckDB target prerequisite (dict + csv `given` require the upstream relation to exist in the warehouse — easiest via a file-backed DuckDB target + `run-operation load_synthea_sources`).

## Related Issues

Related to:
- cmbays/dbt-playground#290 (the original cute-dbt dogfooding PR)
- [breezy-bays-labs/cute-dbt#39](https://github.com/breezy-bays-labs/cute-dbt/issues/39) (closed; this PR provides better dogfooding source)
- [breezy-bays-labs/cute-dbt#66](https://github.com/breezy-bays-labs/cute-dbt/issues/66) (cute-dbt's matching renderer fix for csv + sql formats)

## Type of Change

- [x] Refactoring (no functional changes) — same 3 tests, same assertions, different mock-data shape

## Testing

All 3 tests pass via dbt-core 1.11.11 against a persistent DuckDB target:

```
$ dbt run-operation load_synthea_sources --target unit_test
[All Synthea sources loaded successfully!]

$ dbt build --empty --select "+mart_dq_summary +dim_payers" --target unit_test
[Completed successfully]

$ dbt test --select "test_type:unit" --target unit_test
1 of 3 PASS dim_payers::test_dim_payers_injects_unknown_sentinel
2 of 3 PASS mart_dq_summary::test_mart_dq_summary_combines_encounter_and_medication_metrics
3 of 3 PASS mart_dq_summary::test_mart_dq_summary_zero_quarantined_when_all_valid
Completed successfully
Done. PASS=3 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=3
```

### Manual Testing

UI-specific test items (Chrome/Firefox/Safari/localStorage) are N/A — this PR only modifies dbt YAML + README.

### Specific Test Cases

1. **dim_payers dict given/expect**: dim_payers UNION-ALL with unknown sentinel preserves payer_key=-1 + sequenced surrogate keys starting at 1.
2. **mart_dq_summary csv given/expect**: 2 encounter rows (1 invalid) + 2 medication rows (both invalid) → encounters quarantined_count=1 (50% rate), medications quarantined_count=2 (100% rate).
3. **mart_dq_summary sql given + dict expect**: all-valid rows produce zero quarantined_count + 0.00 rate per entity. dict expect skips the non-deterministic `_generated_at` column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)