### PR TITLE
chore(unit-tests): add comment-bracket demo comments around the cute-dbt dogfooding unit_tests

### DIFF
--- a/dbt_project/models/marts/analytics/_analytics__models.yml
+++ b/dbt_project/models/marts/analytics/_analytics__models.yml
@@ -1308,6 +1308,10 @@ models:
 # test_type:unit`.
 
 unit_tests:
+  # LEADING bracket for test 1 — the slicer attaches contiguous
+  # `#`-comment lines at the SAME indent as `- name:` immediately above
+  # the test (no blank-line gap below) to this test's authored slice
+  # (cute-dbt#69 / #73).
   - name: test_mart_dq_summary_combines_encounter_and_medication_metrics
     description: |
       mart_dq_summary UNION-ALLs metrics from stg_synthea__encounters
@@ -1317,6 +1321,9 @@ unit_tests:
       GIVEN and EXPECT — compact tabular form across many boolean
       dq-flag columns.
     model: mart_dq_summary
+    # INSIDE bracket for test 1 — comments at deeper indent than
+    # `- name:` ride along with the body slice as raw text (cute-dbt#69
+    # / #73).
     given:
       - input: ref('stg_synthea__encounters')
         format: csv
@@ -1336,7 +1343,13 @@ unit_tests:
         entity_type,quarantined_count,total_count,quarantine_rate_pct,failed_timestamp_validations
         encounters,1,2,50.00,1
         medications,2,2,100.00,1
+  # TRAILING bracket for test 1 — the comment block butts against the
+  # body above (no blank-line gap) and is terminated below by the blank
+  # line separating the two tests (cute-dbt#69 / #73).
 
+  # LEADING bracket for test 2 — sits between the blank-line
+  # terminator above and `- name:` below with no further gap, so the
+  # leading-wins tiebreaker is moot here (cute-dbt#69 / #73).
   - name: test_mart_dq_summary_zero_quarantined_when_all_valid
     description: |
       mart_dq_summary should report zero quarantined_count and 0.00
@@ -1346,6 +1359,9 @@ unit_tests:
       non-deterministic outputs (`_generated_at` from
       `current_timestamp`) are excluded from comparison.
     model: mart_dq_summary
+    # INSIDE bracket for test 2 — same rule as test 1 (cute-dbt#69 /
+    # #73). Demonstrates that the slicer ride-along applies to every
+    # unit_test, not just the first in the file.
     given:
       - input: ref('stg_synthea__encounters')
         format: sql
@@ -1376,3 +1392,5 @@ unit_tests:
           quarantined_count: 0
           total_count: 1
           quarantine_rate_pct: 0.00
+  # TRAILING bracket for test 2 — terminated by EOF (cute-dbt#69 /
+  # #73).

--- a/dbt_project/models/marts/core/_core__models.yml
+++ b/dbt_project/models/marts/core/_core__models.yml
@@ -1155,6 +1155,11 @@ models:
 # and asserts the SQL transformation produces the expected shape.
 
 unit_tests:
+  # cute-dbt's authoring-YAML drawer (since #69) attaches contiguous
+  # `#`-comment lines at the SAME indent as `- name:` immediately above
+  # the test to the test's authored slice. This block demonstrates the
+  # LEADING bracket — useful for stating the test's intent before the
+  # reader sees the assertion (cute-dbt#73).
   - name: test_dim_payers_injects_unknown_sentinel
     description: |
       dim_payers UNION-ALLs an unknown-member sentinel row (payer_key = -1)
@@ -1165,6 +1170,9 @@ unit_tests:
       outputs (`_loaded_at` via `current_timestamp`) are excluded from
       assertion automatically.
     model: dim_payers
+    # The INSIDE bracket — comments at deeper indent than `- name:` ride
+    # along with the body slice as raw text. Cute-dbt preserves them
+    # verbatim in the Authoring YAML drawer (cute-dbt#73).
     given:
       - input: ref('stg_synthea__payers')
         format: dict
@@ -1199,3 +1207,7 @@ unit_tests:
         - payer_key: 1
           payer_id: 'a00000aa-0000-0000-0000-000000000001'
           payer_name: 'Acme Health'
+  # The TRAILING bracket — contiguous `#`-comment lines at the SAME
+  # indent as `- name:`, immediately following the test body and
+  # terminated by EOF or a blank line, are attached to this test's
+  # slice. Useful for cross-references and follow-up notes (cute-dbt#73).


### PR DESCRIPTION
## Summary

- Add contiguous `#`-comment lines in all three bracketing positions (leading / inside / trailing) around each of the three cute-dbt dogfooding `unit_tests` — one in `_core__models.yml`, two in `_analytics__models.yml`.
- Closes the visible-coverage gap flagged at https://github.com/breezy-bays-labs/cute-dbt/issues/73 — cute-dbt's authoring-YAML drawer slicer has 22 inline tests covering the bracketing contract exhaustively, but the **rendered playground report** (the artifact reviewers download from cute-dbt's PR sticky-comment workflow) had no comments to display.
- No behavior change for `dbt test --select test_type:unit`. dbt-core 1.11+ parses the schema cleanly; manifest still reports 3 unit_tests on schema v12 with unchanged `original_file_path`.

## What changed

- `dbt_project/models/marts/core/_core__models.yml` (+12 lines) — `test_dim_payers_injects_unknown_sentinel` gets leading + inside + trailing comments.
- `dbt_project/models/marts/analytics/_analytics__models.yml` (+18 lines) — both `test_mart_dq_summary_*` tests get leading + inside + trailing comments. The two tests share a blank-line separator: test 1's trailing block terminates at the blank line above test 2's leading block (demonstrates the slicer's per-test bracket termination rule).

## Why this matters

cute-dbt is the user's open-source dbt unit-test HTML explorer in `breezy-bays-labs/cute-dbt`. This playground (`cmbays/dbt-playground`) is the upstream source-of-truth for cute-dbt's largest example fixture, pinned by commit SHA in cute-dbt's `tests/fixtures/MANIFEST.toml`. Adding the comments here lets cute-dbt's regenerated example HTML showcase the Authoring YAML drawer rendering comments end-to-end.

## Test plan

- [x] `dbt deps` + `dbt parse` succeed (schema v12, 3 unit_tests preserved)
- [x] YAML loads cleanly via `pyyaml.safe_load`
- [x] No structural changes to model definitions, only added comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)