### PR TITLE
cross-join demo model + source-given unit test (cute-dbt#64 / cute-dbt#57)

### DIFF
--- a/dbt_project/.gitignore
+++ b/dbt_project/.gitignore
@@ -4,3 +4,4 @@ logs/
 *.duckdb
 *.duckdb.wal
 data/synthea/*.csv
+dbt_internal_packages/

--- a/dbt_project/models/marts/analytics/_analytics__models.yml
+++ b/dbt_project/models/marts/analytics/_analytics__models.yml
@@ -1288,18 +1288,76 @@ models:
       - name: _generated_at
         description: "Timestamp when summary was generated"
 
+  - name: mart_date_state_grid
+    description: |
+      Dense month x state reporting scaffold.
+      One row per (calendar month x patient state) combination — the full
+      cartesian product of dim_date months and the non-null states observed
+      in patient staging. Left-join sparse activity facts against this grid
+      so zero-activity cells render as explicit zeros.
+      Grain: month_key x state
+
+      Use cases:
+      - Dense time-series dashboards (no missing month/state cells)
+      - Zero-activity gap detection
+      - cute-dbt cross-join CTE-edge demo (cute-dbt#64)
+
+    data_tests:
+      # New-style `arguments:` nesting (fusion-clean; dbt-core 1.10+).
+      # The legacy top-level-args form elsewhere in this file predates
+      # the planned dbt-autofix sweep.
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - month_key
+              - state
+
+    config:
+      tags: ['analytics', 'reporting', 'marts']
+      meta:
+        grain: month_key x state
+        owner: healthcare_analytics
+        uses:
+          - "Dense reporting grids"
+          - "Zero-activity gap detection"
+
+    columns:
+      - name: month_key
+        description: "Month surrogate key in YYYYMM integer form (e.g., 202401)"
+        data_tests:
+          - not_null
+
+      - name: year_actual
+        description: "Calendar year of the grid cell"
+        data_tests:
+          - not_null
+
+      - name: month_actual
+        description: "Calendar month number (1-12) of the grid cell"
+        data_tests:
+          - not_null
+
+      - name: month_name
+        description: "Full month name (e.g., January)"
+
+      - name: state
+        description: "Patient state, distinct and non-null from staging"
+        data_tests:
+          - not_null
+
 
 # ============================================================================
 # UNIT TESTS
 # ============================================================================
 # These unit_tests are authored to exercise the cute-dbt unit-test explorer
 # (https://github.com/breezy-bays-labs/cute-dbt) against this playground's
-# UNION-bearing analytics mart. They intentionally exercise different
+# UNION-bearing analytics marts. They intentionally exercise different
 # fixture formats for `given` (and `expect` where relevant): one csv,
-# one sql. dim_payers (_core__models.yml) covers the dict format.
-# Together the three tests pin cute-dbt's renderer against every dbt
-# 1.8+ unit_test fixture format. See `_core__models.yml` for the third
-# test (test_dim_payers_injects_unknown_sentinel).
+# one sql, one mixed dict+csv. dim_payers (_core__models.yml) covers the
+# pure-dict format. Together the tests pin cute-dbt's renderer against
+# every dbt 1.8+ unit_test fixture format. See `_core__models.yml` for
+# test_dim_payers_injects_unknown_sentinel, and `_synthea__models.yml`
+# for the source()-given test (cute-dbt#57).
 #
 # **Test-execution prerequisite**: dict and csv given formats introspect
 # the upstream model's schema (to NULL-fill unspecified columns). Run
@@ -1392,5 +1450,51 @@ unit_tests:
           quarantined_count: 0
           total_count: 1
           quarantine_rate_pct: 0.00
-  # TRAILING bracket for test 2 — terminated by EOF (cute-dbt#69 /
-  # #73).
+  # TRAILING bracket for test 2 — terminated by the blank line
+  # separating it from test 3 (cute-dbt#69 / #73).
+
+  # Cross-join demo (cute-dbt#64): mart_date_state_grid's CROSS JOIN
+  # CTE gives cute-dbt's renderer a real cross-join edge to draw. This
+  # test also mixes given formats (dict + csv) in a single unit_test.
+  - name: test_mart_date_state_grid_cross_joins_months_and_states
+    description: |
+      mart_date_state_grid CROSS JOINs the distinct calendar months from
+      dim_date with the distinct non-null patient states from staging.
+      Three daily dim_date rows collapse to two months; four patient
+      rows collapse to two states (one NULL filtered out, one duplicate
+      deduplicated). The result is the full 2 x 2 cartesian product —
+      four grid rows. Mixes a dict given (dim_date) with a csv given
+      (patients) in one test.
+    model: mart_date_state_grid
+    given:
+      - input: ref('dim_date')
+        format: dict
+        rows:
+          - date_actual: 2024-01-15
+            year_actual: 2024
+            month_actual: 1
+            month_name: 'January'
+          - date_actual: 2024-01-16
+            year_actual: 2024
+            month_actual: 1
+            month_name: 'January'
+          - date_actual: 2024-02-01
+            year_actual: 2024
+            month_actual: 2
+            month_name: 'February'
+      - input: ref('stg_synthea__patients')
+        format: csv
+        rows: |
+          patient_id,state
+          a00000aa-0000-0000-0000-000000000001,Massachusetts
+          a00000aa-0000-0000-0000-000000000002,Connecticut
+          a00000aa-0000-0000-0000-000000000003,
+          a00000aa-0000-0000-0000-000000000004,Massachusetts
+    expect:
+      format: csv
+      rows: |
+        month_key,year_actual,month_actual,month_name,state
+        202401,2024,1,January,Massachusetts
+        202401,2024,1,January,Connecticut
+        202402,2024,2,February,Massachusetts
+        202402,2024,2,February,Connecticut

--- a/dbt_project/models/marts/analytics/mart_date_state_grid.sql
+++ b/dbt_project/models/marts/analytics/mart_date_state_grid.sql
@@ -1,0 +1,45 @@
+{{
+    config(
+        materialized='table',
+        tags=['analytics', 'reporting']
+    )
+}}
+
+{#
+    Dense month x state reporting grid.
+
+    Cross joins every calendar month from dim_date with every non-null
+    patient state observed in staging. Left-join sparse activity facts
+    against this grid so zero-activity month/state cells render as
+    explicit zeros instead of silently disappearing from dashboards.
+
+    The explicit CROSS JOIN inside a CTE doubles as the cute-dbt
+    cross-join CTE-edge demo (cute-dbt#64).
+#}
+
+with months as (
+    select distinct
+        year_actual
+        , month_actual
+        , month_name
+    from {{ ref('dim_date') }}
+),
+
+states as (
+    select distinct state
+    from {{ ref('stg_synthea__patients') }}
+    where state is not null
+),
+
+grid as (
+    select
+        cast(months.year_actual * 100 + months.month_actual as integer) as month_key
+        , months.year_actual
+        , months.month_actual
+        , months.month_name
+        , states.state
+    from months
+    cross join states
+)
+
+select * from grid

--- a/dbt_project/models/staging/synthea/_synthea__models.yml
+++ b/dbt_project/models/staging/synthea/_synthea__models.yml
@@ -859,3 +859,45 @@ models:
 
       - name: _loaded_at
         description: Timestamp when record was loaded into staging
+
+
+# ============================================================================
+# UNIT TESTS
+# ============================================================================
+# Source-given fixture (cute-dbt#57): unlike the ref()-given unit_tests
+# in the marts YAML files, this test mocks a dbt SOURCE input —
+# `source('synthea_raw', 'patients')` — giving cute-dbt a real
+# wire-shape fixture for source() given binding.
+
+unit_tests:
+  - name: test_stg_synthea__patients_renames_and_hashes_source_columns
+    description: |
+      stg_synthea__patients renames the raw Synthea UPPERCASE columns to
+      snake_case and hashes the SSN with md5. The given mocks the
+      synthea_raw.patients SOURCE directly (inline dict rows) — the only
+      unit test in this project whose input is a source() rather than a
+      ref() (cute-dbt#57). Dict expect compares listed columns only, so
+      the non-deterministic _loaded_at (current_timestamp) is excluded
+      from assertion automatically.
+    model: stg_synthea__patients
+    given:
+      - input: source('synthea_raw', 'patients')
+        format: dict
+        rows:
+          - Id: 'c0000000-0000-0000-0000-000000000001'
+            FIRST: 'Ada'
+            LAST: 'Lovelace'
+            GENDER: 'F'
+            CITY: 'Boston'
+            STATE: 'Massachusetts'
+            SSN: '999-99-9999'
+    expect:
+      format: dict
+      rows:
+        - patient_id: 'c0000000-0000-0000-0000-000000000001'
+          first_name: 'Ada'
+          last_name: 'Lovelace'
+          gender: 'F'
+          city: 'Boston'
+          state: 'Massachusetts'
+          ssn_hash: '257cf696294931925796925d89aa0afb'


### PR DESCRIPTION
## Task A — cross-join demo model (serves https://github.com/breezy-bays-labs/cute-dbt/issues/64)

Adds `mart_date_state_grid` (marts/analytics): a dense month x state reporting grid — every calendar month from `dim_date` CROSS JOINed with every distinct non-null patient state from `stg_synthea__patients`. A realistic analytics scaffold (left-join sparse facts against it so zero-activity cells render as explicit zeros) whose **explicit `CROSS JOIN` inside a CTE** gives cute-dbt's CTE engine a real cross-join edge to render.

- Model entry in `_analytics__models.yml` with descriptions + data tests (unique `month_key` x `state` combination via dbt_utils, not_nulls). The model-level test uses the new `arguments:` nesting and `config.meta` so it is **fusion-clean** (the legacy-format entries elsewhere await the dbt-autofix sweep).
- Unit test `test_mart_date_state_grid_cross_joins_months_and_states`: 3 daily `dim_date` rows collapse to 2 months, 4 patient rows collapse to 2 states (one NULL filtered, one duplicate deduplicated) → asserts the full 2 x 2 cartesian product (4 rows). Mixes **dict + csv given formats in one test** — itself a useful cute-dbt fixture shape.

The cute-dbt-side fixture regen + golden `examples/playground-report.html` re-render follows in a **separate cute-dbt PR**.

## Task B — source-given unit test (serves https://github.com/breezy-bays-labs/cute-dbt/issues/57)

No existing playground unit test mocked a dbt **source** as a given. Adds `test_stg_synthea__patients_renames_and_hashes_source_columns` (`_synthea__models.yml`): the given mocks `source('synthea_raw', 'patients')` directly with inline dict rows (raw UPPERCASE Synthea columns), asserting the snake_case rename + md5 SSN hash. This is the project's only source()-given unit test — a real wire-shape fixture for cute-dbt#57's source() given-binding work.

## Verification (both engines)

| Check | Result |
|---|---|
| dbt-core 1.11.2 `parse` + `compile` | clean |
| All 5 unit tests (`dbt test --select test_type:unit`, persistent duckdb target recipe) | **5/5 PASS** (incl. both new) |
| Real `dbt build --select +mart_date_state_grid` (non-empty) | model + 5 data tests PASS |
| dbt-fusion 2.0.0-preview.177 `compile` | **zero errors in the added regions**; 166 pre-existing dbt1159/dbt1060 errors project-wide (legacy test-arg format, pre-dates this PR — dbt-autofix sweep tracked in cute-dbt#64's discovery notes) |
| sqlfluff (duckdb dialect, dbt templater) + yamllint | clean |

All data synthetic. No `target/` artifacts or manifests committed. The `dbt_internal_packages/` gitignore line was auto-appended by dbt-fusion during verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)